### PR TITLE
Feature/gitapi, Fix : fix get last commit hash

### DIFF
--- a/smartcontract/infra/service/itcode_store_git_api.go
+++ b/smartcontract/infra/service/itcode_store_git_api.go
@@ -44,9 +44,12 @@ func (g GitApi) Clone(gitUrl string) (*smartContract.SmartContract, error) {
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 
-	committer, err := r.CommitObjects()
-	lastCommit, err := committer.Next()
-	commitHash := lastCommit.Hash.String()
+	head, err := r.Head()
+	if err != nil {
+		return nil, err
+	}
+	lastHeadCommit, err := r.CommitObject(head.Hash())
+	commitHash := lastHeadCommit.Hash.String()
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
smartcontract/infra/service/itrcode_store_git_api
공부하면서 소스코드랑 go doc 읽어봤는데
commitObjects로 commiter를 얻어오면 unsorted 라고 하네요
(https://godoc.org/gopkg.in/src-d/go-git.v4#Repository.CommitObjects)
reference를 얻어올때는 정렬되서 온다고 하니
HEAD 기준으로 last commit을 가져오는걸로 바꿔봤습니다~