### PR TITLE
junksound: modify block_service_test.go - delete dependency on .it-chain

### DIFF
--- a/blockchain/block_config_test.go
+++ b/blockchain/block_config_test.go
@@ -26,9 +26,9 @@ func TestConfigFromJson(t *testing.T) {
 								  "TimeStamp":"0001-01-01T00:00:00-00:00",
 								  "Creator":[]
 								}`)
-	var tempBlock impl.DefaultBlock
-	_ = json.Unmarshal(GenesisBlockConfigJson, &tempBlock)
-	GenesisBlockConfigByte, _ := json.Marshal(tempBlock)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
 	_ = ioutil.WriteFile(genesisFilePath, GenesisBlockConfigByte, 0644)
 	_, err1 := ConfigFromJson(genesisFilePath)
 	assert.NoError(t, err1)

--- a/blockchain/block_config_test.go
+++ b/blockchain/block_config_test.go
@@ -1,17 +1,36 @@
 package blockchain
 
 import (
-	"go/build"
 	"testing"
 
+	"os"
+
+	"io/ioutil"
+
+	"encoding/json"
+
+	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigFromJson(t *testing.T) {
-	genesisconfPath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/"
-	rightFilePath := genesisconfPath + "GenesisBlockConfig.json"
-	wrongFilePath := genesisconfPath + "WrongFileName.json"
-	_, err1 := ConfigFromJson(rightFilePath)
+	genesisFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(genesisFilePath)
+	wrongFilePath := "./WrongFileName.json"
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempBlock impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempBlock)
+	GenesisBlockConfigByte, _ := json.Marshal(tempBlock)
+	_ = ioutil.WriteFile(genesisFilePath, GenesisBlockConfigByte, 0644)
+	_, err1 := ConfigFromJson(genesisFilePath)
 	assert.NoError(t, err1)
 	_, err2 := ConfigFromJson(wrongFilePath)
 	assert.Error(t, err2)

--- a/blockchain/block_config_test.go
+++ b/blockchain/block_config_test.go
@@ -1,35 +1,30 @@
 package blockchain
 
 import (
-	"testing"
-
-	"os"
-
-	"io/ioutil"
-
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
 
 	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigFromJson(t *testing.T) {
+
 	genesisFilePath := "./GenesisBlockConfig.json"
-	defer os.Remove(genesisFilePath)
 	wrongFilePath := "./WrongFileName.json"
-	GenesisBlockConfigJson := []byte(`{
-								  "Seal":[],
-								  "PrevSeal":[],
-								  "Height":0,
-								  "TxList":[],
-								  "TxSeal":[],
-								  "TimeStamp":"0001-01-01T00:00:00-00:00",
-								  "Creator":[]
-								}`)
 	var tempJson impl.DefaultBlock
-	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+
+	err := json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	assert.NoError(t, err)
+
 	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
-	_ = ioutil.WriteFile(genesisFilePath, GenesisBlockConfigByte, 0644)
+	err = ioutil.WriteFile(genesisFilePath, GenesisBlockConfigByte, 0644)
+	assert.NoError(t, err)
+
+	defer os.Remove(genesisFilePath)
+
 	_, err1 := ConfigFromJson(genesisFilePath)
 	assert.NoError(t, err1)
 	_, err2 := ConfigFromJson(wrongFilePath)

--- a/blockchain/block_service_test.go
+++ b/blockchain/block_service_test.go
@@ -1,26 +1,17 @@
 package blockchain
 
 import (
-	"testing"
-
 	"encoding/json"
-
 	"io/ioutil"
-
 	"os"
-
+	"testing"
 	"time"
 
 	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateGenesisBlock(t *testing.T) {
-
-	GenesisFilePath := "./GenesisBlockConfig.json"
-	defer os.Remove(GenesisFilePath)
-	wrongFilePath := "./WrongFileName.json"
-	GenesisBlockConfigJson := []byte(`{
+var GenesisBlockConfigJson = []byte(`{
 								  "Seal":[],
 								  "PrevSeal":[],
 								  "Height":0,
@@ -29,11 +20,22 @@ func TestCreateGenesisBlock(t *testing.T) {
 								  "TimeStamp":"0001-01-01T00:00:00-00:00",
 								  "Creator":[]
 								}`)
+
+func TestCreateGenesisBlock(t *testing.T) {
+
+	GenesisFilePath := "./GenesisBlockConfig.json"
+	wrongFilePath := "./WrongFileName.json"
+
 	validator := new(impl.DefaultValidator)
 	var tempBlock impl.DefaultBlock
-	_ = json.Unmarshal(GenesisBlockConfigJson, &tempBlock)
+	err := json.Unmarshal(GenesisBlockConfigJson, &tempBlock)
+	assert.NoError(t, err)
+
 	GenesisBlockConfigByte, _ := json.Marshal(tempBlock)
-	_ = ioutil.WriteFile(GenesisFilePath, GenesisBlockConfigByte, 0644)
+	err = ioutil.WriteFile(GenesisFilePath, GenesisBlockConfigByte, 0644)
+	assert.NoError(t, err)
+
+	defer os.Remove(GenesisFilePath)
 
 	GenesisBlock, err1 := CreateGenesisBlock(GenesisFilePath)
 	expectedSeal, _ := validator.BuildSeal(GenesisBlock)
@@ -47,5 +49,6 @@ func TestCreateGenesisBlock(t *testing.T) {
 	assert.Equal(t, make([]byte, 0), GenesisBlock.Creator)
 
 	_, err2 := CreateGenesisBlock(wrongFilePath)
+
 	assert.Error(t, err2)
 }

--- a/blockchain/block_test.go
+++ b/blockchain/block_test.go
@@ -1,20 +1,36 @@
 package blockchain
 
 import (
-	"go/build"
 	"os"
 	"testing"
 
 	"time"
+
+	"encoding/json"
+	"io/ioutil"
 
 	"github.com/it-chain/leveldb-wrapper"
 	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
 )
 
-var genesisConfFilePath = build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
-
 func TestBlockRepository_AddBlock(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -22,7 +38,7 @@ func TestBlockRepository_AddBlock(t *testing.T) {
 		os.RemoveAll(dbPath)
 	}()
 
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	validator := new(impl.DefaultValidator)
 	opts := map[string]interface{}{
 		"db_path": dbPath,
@@ -34,10 +50,23 @@ func TestBlockRepository_AddBlock(t *testing.T) {
 }
 
 func TestBlockRepository_GetBlockByHeight(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
-
-	genesisConfFilePath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
-
 	validator := new(impl.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -48,7 +77,7 @@ func TestBlockRepository_GetBlockByHeight(t *testing.T) {
 		"db_path": dbPath,
 	}
 	br := NewBlockRepository(db, *validator, opts)
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	br.AddBlock(*genesisBlock)
 	retrievedBlock, err := br.GetBlockByHeight(0)
 	assert.NoError(t, err)
@@ -56,8 +85,23 @@ func TestBlockRepository_GetBlockByHeight(t *testing.T) {
 }
 
 func TestBlockRepository_GetBlockBySeal(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
-	genesisConfFilePath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
 	validator := new(impl.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -68,7 +112,7 @@ func TestBlockRepository_GetBlockBySeal(t *testing.T) {
 		"db_path": dbPath,
 	}
 	br := NewBlockRepository(db, *validator, opts)
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	br.AddBlock(*genesisBlock)
 	retrievedBlock, err := br.GetBlockBySeal(genesisBlock.Seal)
 	assert.NoError(t, err)
@@ -76,10 +120,23 @@ func TestBlockRepository_GetBlockBySeal(t *testing.T) {
 }
 
 func TestBlockRepository_GetLastBlock(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
-
-	genesisConfFilePath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
-
 	validator := new(impl.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -90,7 +147,7 @@ func TestBlockRepository_GetLastBlock(t *testing.T) {
 		"db_path": dbPath,
 	}
 	br := NewBlockRepository(db, *validator, opts)
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	br.AddBlock(*genesisBlock)
 	retrievedBlock, err := br.GetLastBlock()
 	assert.NoError(t, err)
@@ -98,8 +155,23 @@ func TestBlockRepository_GetLastBlock(t *testing.T) {
 }
 
 func TestBlockRepositoryImpl_GetBlockByTxID(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
-	genesisConfFilePath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
 	validator := new(impl.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -110,7 +182,7 @@ func TestBlockRepositoryImpl_GetBlockByTxID(t *testing.T) {
 		"db_path": dbPath,
 	}
 	br := NewBlockRepository(db, *validator, opts)
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	tx := &impl.DefaultTransaction{
 		PeerID:    "p01",
 		ID:        "tx01",
@@ -138,8 +210,23 @@ func TestBlockRepositoryImpl_GetBlockByTxID(t *testing.T) {
 }
 
 func TestBlockRepositoryImpl_GetTransactionByTxID(t *testing.T) {
+	GenesisConfFilePath := "./GenesisBlockConfig.json"
+	defer os.Remove(GenesisConfFilePath)
+	GenesisBlockConfigJson := []byte(`{
+								  "Seal":[],
+								  "PrevSeal":[],
+								  "Height":0,
+								  "TxList":[],
+								  "TxSeal":[],
+								  "TimeStamp":"0001-01-01T00:00:00-00:00",
+								  "Creator":[]
+								}`)
+	var tempJson impl.DefaultBlock
+	_ = json.Unmarshal(GenesisBlockConfigJson, &tempJson)
+	GenesisBlockConfigByte, _ := json.Marshal(tempJson)
+	_ = ioutil.WriteFile(GenesisConfFilePath, GenesisBlockConfigByte, 0644)
+
 	dbPath := "./.db"
-	genesisConfFilePath := build.Default.GOPATH + "/src/github.com/it-chain/it-chain-Engine/.it-chain/genesisconf/GenesisBlockConfig.json"
 	validator := new(impl.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	defer func() {
@@ -150,7 +237,7 @@ func TestBlockRepositoryImpl_GetTransactionByTxID(t *testing.T) {
 		"db_path": dbPath,
 	}
 	br := NewBlockRepository(db, *validator, opts)
-	genesisBlock, _ := CreateGenesisBlock(genesisConfFilePath)
+	genesisBlock, _ := CreateGenesisBlock(GenesisConfFilePath)
 	tx := &impl.DefaultTransaction{
 		PeerID:    "p01",
 		ID:        "tx01",


### PR DESCRIPTION
<수정 내용>
테스트 케이스가 .it-chain 내 파일에 종속되어 있던 점을 수정하였습니다.

<질문>
의존성이 없어져야 된다고 해서 수정하긴 했는데,
그러면 실제로 블록체인을 처음 만들어서 GenesisBlock을 생성할 때는 어떻게 되는건가요?
config 값을 우리가 만들어주고, 그걸 사용하는 것인 줄 알았는데
이용자들이 .it-chain 내 config 값을 사용할 수 없다면 CreateGenesisBlock을 할 때 문제가 있는 것 아닌가요?