### PR TITLE
Feature/gateway

### DIFF
--- a/gateway/api/message_api.go
+++ b/gateway/api/message_api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/it-chain/it-chain-Engine/gateway"
-	"github.com/it-chain/it-chain-Engine/gateway/infra"
 )
 
 type MessageApi struct {
@@ -16,9 +15,8 @@ func NewMessageApi(grpcService gateway.GrpcService) *MessageApi {
 }
 
 //todo validation rule added example( check length of recipent)
-func (c MessageApi) DeliverMessage(command gateway.MessageDeliverCommand) {
+func (c MessageApi) DeliverMessage(command gateway.GrpcDeliverCommand) {
 
 	//validation rule add
-	hostService := infra.NewGrpcHostService()
 	c.grpcService.SendMessages(command.Body, command.Protocol, command.Recipients...)
 }

--- a/gateway/command.go
+++ b/gateway/command.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"github.com/it-chain/it-chain-Engine/p2p"
 	"github.com/it-chain/midgard"
 )
 
@@ -17,7 +16,7 @@ type ConnectionCloseCommand struct {
 }
 
 //다른 Peer에게 Message전송 command
-type MessageDeliverCommand struct {
+type GrpcDeliverCommand struct {
 	midgard.CommandModel
 	Recipients []string
 	Body       []byte
@@ -25,12 +24,9 @@ type MessageDeliverCommand struct {
 }
 
 //다른 Peer에게 Message수신 command
-type MessageReceiveCommand struct {
+type GrpcReceiveCommand struct {
 	midgard.CommandModel
 	Data         []byte
 	ConnectionID string
 	Protocol     string
-	FromNode     p2p.Node // 메세지를 받는 경우 connectionID 만 있으면 수신자가 불편함이 있을 것 같아 추가했습니다.
-	// 현재 node repo 에서 connection id 를 저장하지 않기 때문에 수신자가 nodeid 를 알 수 없습니다.
-	// -frontalnh
 }

--- a/gateway/command.go
+++ b/gateway/command.go
@@ -26,7 +26,7 @@ type GrpcDeliverCommand struct {
 //다른 Peer에게 Message수신 command
 type GrpcReceiveCommand struct {
 	midgard.CommandModel
-	Data         []byte
+	Body         []byte
 	ConnectionID string
 	Protocol     string
 }

--- a/gateway/infra/grpc_service.go
+++ b/gateway/infra/grpc_service.go
@@ -236,8 +236,8 @@ type MessageHandler struct {
 
 func (r MessageHandler) ServeRequest(msg bifrost.Message) {
 
-	err := r.publish("Command", "message.receive", gateway.MessageReceiveCommand{
-		Data:         msg.Data,
+	err := r.publish("Command", "message.receive", gateway.GrpcReceiveCommand{
+		Body:         msg.Data,
 		ConnectionID: msg.Conn.GetID(),
 	})
 

--- a/gateway/infra/grpc_service_test.go
+++ b/gateway/infra/grpc_service_test.go
@@ -52,7 +52,7 @@ func TestMessageHandler_ServeRequest(t *testing.T) {
 	//given
 	tests := map[string]struct {
 		input  bifrost.Message
-		output gateway.MessageReceiveCommand
+		output gateway.GrpcReceiveCommand
 		err    error
 	}{
 		"success": {
@@ -62,8 +62,8 @@ func TestMessageHandler_ServeRequest(t *testing.T) {
 					ID: "123",
 				},
 			},
-			output: gateway.MessageReceiveCommand{
-				Data:         []byte("hello world"),
+			output: gateway.GrpcReceiveCommand{
+				Body:         []byte("hello world"),
 				ConnectionID: "123",
 			},
 			err: nil,
@@ -75,8 +75,8 @@ func TestMessageHandler_ServeRequest(t *testing.T) {
 		//then
 		assert.Equal(t, exchange, "Command")
 		assert.Equal(t, topic, "message.receive")
-		assert.Equal(t, data, gateway.MessageReceiveCommand{
-			Data:         []byte("hello world"),
+		assert.Equal(t, data, gateway.GrpcReceiveCommand{
+			Body:         []byte("hello world"),
 			ConnectionID: "123",
 		})
 		return nil
@@ -308,8 +308,8 @@ func TestGrpcHostService_SendMessages(t *testing.T) {
 
 		assert.Equal(t, exchange, "Command")
 		assert.Equal(t, topic, "message.receive")
-		assert.Equal(t, data, gateway.MessageReceiveCommand{
-			Data:         publishedData,
+		assert.Equal(t, data, gateway.GrpcReceiveCommand{
+			Body:         publishedData,
 			ConnectionID: connID,
 		})
 		return nil

--- a/gateway/main/gateway.go
+++ b/gateway/main/gateway.go
@@ -7,7 +7,6 @@ import (
 	"github.com/it-chain/it-chain-Engine/gateway/infra"
 	"github.com/it-chain/midgard"
 	"github.com/it-chain/midgard/bus/rabbitmq"
-	"github.com/it-chain/midgard/store"
 	"github.com/it-chain/midgard/store/leveldb"
 )
 
@@ -27,7 +26,7 @@ func Start(ampqUrl string, grpcUrl string, keyPath string) error {
 	//midgard EventStore
 	repository := midgard.NewRepo(leveldb.NewEventStore(
 		".gateway/eventStore",
-		store.NewSerializer(gateway.ConnectionCreatedEvent{}, gateway.ConnectionDisconnectedEvent{}, gateway.ErrorCreatedEvent{}),
+		leveldb.NewSerializer(gateway.ConnectionCreatedEvent{}, gateway.ConnectionDisconnectedEvent{}, gateway.ErrorCreatedEvent{}),
 	), rabbitmqClient)
 
 	//createHandler


### PR DESCRIPTION
#252 수정했습니다.
grpc는 오로지 2개의 command, 

```
//다른 Peer에게 Message전송 command
type GrpcDeliverCommand struct {
	midgard.CommandModel
	Recipients []string
	Body       []byte
	Protocol   string
}

//다른 Peer에게 Message수신 command
type GrpcReceiveCommand struct {
	midgard.CommandModel
	Body         []byte
	ConnectionID string
	Protocol     string
}
```
로 하겠습니다.