### PR TITLE
Blockchain/grpc-command-service

### DIFF
--- a/blockchain/infra/adapter/grpc_command_service.go
+++ b/blockchain/infra/adapter/grpc_command_service.go
@@ -27,9 +27,9 @@ func NewGrpcCommandService(publish Publish) *GrpcCommandService {
 	}
 }
 
-func (gcs *GrpcCommandService) RequestBlock(nodeId p2p.NodeId, height uint64) error {
+func (gcs *GrpcCommandService) RequestBlock(peerId p2p.PeerId, height uint64) error {
 
-	if nodeId.Id == "" {
+	if peerId.Id == "" {
 		return ErrEmptyNodeId
 	}
 
@@ -42,14 +42,14 @@ func (gcs *GrpcCommandService) RequestBlock(nodeId p2p.NodeId, height uint64) er
 		return err
 	}
 
-	deliverCommand.Recipients = append(deliverCommand.Recipients, nodeId.ToString())
+	deliverCommand.Recipients = append(deliverCommand.Recipients, peerId.ToString())
 
 	return gcs.publish("Command", "message.deliver", deliverCommand)
 }
 
-func (gcs *GrpcCommandService) ResponseBlock(nodeId p2p.NodeId, block blockchain.Block) error {
+func (gcs *GrpcCommandService) ResponseBlock(peerId p2p.PeerId, block blockchain.Block) error {
 
-	if nodeId.Id == "" {
+	if peerId.Id == "" {
 		return ErrEmptyNodeId
 	}
 
@@ -64,7 +64,7 @@ func (gcs *GrpcCommandService) ResponseBlock(nodeId p2p.NodeId, block blockchain
 		return err
 	}
 
-	deliverCommand.Recipients = append(deliverCommand.Recipients, nodeId.ToString())
+	deliverCommand.Recipients = append(deliverCommand.Recipients, peerId.ToString())
 
 	return gcs.publish("Command", "message.deliver", deliverCommand)
 }

--- a/blockchain/infra/adapter/grpc_command_service.go
+++ b/blockchain/infra/adapter/grpc_command_service.go
@@ -48,7 +48,6 @@ func (gcs *GrpcCommandService) RequestBlock(peerId p2p.PeerId, height uint64) er
 }
 
 func (gcs *GrpcCommandService) ResponseBlock(peerId p2p.PeerId, block blockchain.Block) error {
-
 	if peerId.Id == "" {
 		return ErrEmptyNodeId
 	}

--- a/blockchain/infra/adapter/grpc_command_service_test.go
+++ b/blockchain/infra/adapter/grpc_command_service_test.go
@@ -5,72 +5,11 @@ import (
 
 	"reflect"
 
-	"time"
-
 	"github.com/it-chain/it-chain-Engine/blockchain/infra/adapter"
 	"github.com/it-chain/it-chain-Engine/p2p"
-	"github.com/it-chain/yggdrasill/common"
+	"github.com/it-chain/yggdrasill/impl"
 	"github.com/stretchr/testify/assert"
 )
-
-type MockBlock struct {
-	seal []byte
-}
-
-func (MockBlock) SetSeal(seal []byte) {
-	panic("implement me")
-}
-func (MockBlock) SetPrevSeal(prevseal []byte) {
-	panic("implement me")
-}
-func (MockBlock) SetHeight(height uint64) {
-	panic("implement me")
-}
-func (MockBlock) PutTx(tx common.Transaction) error {
-	panic("implement me")
-}
-func (MockBlock) SetTxSeal(txSeal [][]byte) {
-	panic("implement me")
-}
-func (MockBlock) SetCreator(creator []byte) {
-	panic("implement me")
-}
-func (MockBlock) SetTimestamp(currentTime time.Time) {
-	panic("implement me")
-}
-func (m MockBlock) GetSeal() []byte {
-	return m.seal
-}
-func (MockBlock) GetPrevSeal() []byte {
-	panic("implement me")
-}
-func (MockBlock) GetHeight() uint64 {
-	panic("implement me")
-}
-func (MockBlock) GetTxList() []common.Transaction {
-	panic("implement me")
-}
-func (MockBlock) GetTxSeal() [][]byte {
-	panic("implement me")
-}
-func (MockBlock) GetCreator() []byte {
-	panic("implement me")
-}
-func (MockBlock) GetTimestamp() time.Time {
-	panic("implement me")
-}
-func (MockBlock) Serialize() ([]byte, error) {
-	panic("implement me")
-}
-func (MockBlock) Deserialize(serializedBlock []byte) error {
-	panic("implement me")
-}
-func (MockBlock) IsReadyToPublish() bool {
-	panic("implement me")
-}
-func (MockBlock) IsPrev(serializedPrevBlock []byte) bool {
-	panic("implement me")
-}
 
 func TestGrpcCommandService_RequestBlock(t *testing.T) {
 
@@ -127,20 +66,20 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 	tests := map[string]struct {
 		input struct {
 			PeerId p2p.PeerId
-			block  MockBlock
+			block  impl.DefaultBlock
 		}
 		err error
 	}{
 		"success: request block": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  MockBlock
+				block  impl.DefaultBlock
 			}{
 				PeerId: p2p.PeerId{
 					Id: "1",
 				},
-				block: MockBlock{
-					seal: []byte("seal"),
+				block: impl.DefaultBlock{
+					Seal: []byte("seal"),
 				},
 			},
 			err: nil,
@@ -148,11 +87,11 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		"fail: empty node id": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  MockBlock
+				block  impl.DefaultBlock
 			}{
 				PeerId: p2p.PeerId{},
-				block: MockBlock{
-					seal: []byte("seal"),
+				block: impl.DefaultBlock{
+					Seal: []byte("seal"),
 				},
 			},
 			err: adapter.ErrEmptyNodeId,
@@ -160,13 +99,13 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		"fail: empty block seal": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  MockBlock
+				block  impl.DefaultBlock
 			}{
 				PeerId: p2p.PeerId{
 					"1",
 				},
-				block: MockBlock{
-					seal: nil,
+				block: impl.DefaultBlock{
+					Seal: nil,
 				},
 			},
 			err: adapter.ErrEmptyBlockSeal,
@@ -185,7 +124,7 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
-		err := GrpcCommandService.ResponseBlock(test.input.PeerId, test.input.block)
+		err := GrpcCommandService.ResponseBlock(test.input.PeerId, &test.input.block)
 		assert.Equal(t, err, test.err)
 	}
 

--- a/blockchain/infra/adapter/grpc_command_service_test.go
+++ b/blockchain/infra/adapter/grpc_command_service_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type DefaultBlock = impl.DefaultBlock
+
 func TestGrpcCommandService_RequestBlock(t *testing.T) {
 
 	tests := map[string]struct {
@@ -66,19 +68,19 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 	tests := map[string]struct {
 		input struct {
 			PeerId p2p.PeerId
-			block  impl.DefaultBlock
+			block  DefaultBlock
 		}
 		err error
 	}{
 		"success: request block": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  impl.DefaultBlock
+				block  DefaultBlock
 			}{
 				PeerId: p2p.PeerId{
 					Id: "1",
 				},
-				block: impl.DefaultBlock{
+				block: DefaultBlock{
 					Seal: []byte("seal"),
 				},
 			},
@@ -87,10 +89,10 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		"fail: empty node id": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  impl.DefaultBlock
+				block  DefaultBlock
 			}{
 				PeerId: p2p.PeerId{},
-				block: impl.DefaultBlock{
+				block: DefaultBlock{
 					Seal: []byte("seal"),
 				},
 			},
@@ -99,12 +101,12 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		"fail: empty block seal": {
 			input: struct {
 				PeerId p2p.PeerId
-				block  impl.DefaultBlock
+				block  DefaultBlock
 			}{
 				PeerId: p2p.PeerId{
 					"1",
 				},
-				block: impl.DefaultBlock{
+				block: DefaultBlock{
 					Seal: nil,
 				},
 			},

--- a/blockchain/infra/adapter/grpc_command_service_test.go
+++ b/blockchain/infra/adapter/grpc_command_service_test.go
@@ -76,17 +76,17 @@ func TestGrpcCommandService_RequestBlock(t *testing.T) {
 
 	tests := map[string]struct {
 		input struct {
-			nodeId p2p.NodeId
+			PeerId p2p.PeerId
 			height uint64
 		}
 		err error
 	}{
 		"success: request block": {
 			input: struct {
-				nodeId p2p.NodeId
+				PeerId p2p.PeerId
 				height uint64
 			}{
-				nodeId: p2p.NodeId{
+				PeerId: p2p.PeerId{
 					Id: "1",
 				},
 				height: uint64(0),
@@ -95,10 +95,10 @@ func TestGrpcCommandService_RequestBlock(t *testing.T) {
 		},
 		"fail: empty node id": {
 			input: struct {
-				nodeId p2p.NodeId
+				PeerId p2p.PeerId
 				height uint64
 			}{
-				nodeId: p2p.NodeId{},
+				PeerId: p2p.PeerId{},
 				height: uint64(0),
 			},
 			err: adapter.ErrEmptyNodeId,
@@ -116,7 +116,7 @@ func TestGrpcCommandService_RequestBlock(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
-		err := GrpcCommandService.RequestBlock(test.input.nodeId, test.input.height)
+		err := GrpcCommandService.RequestBlock(test.input.PeerId, test.input.height)
 		assert.Equal(t, err, test.err)
 	}
 
@@ -126,17 +126,17 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 
 	tests := map[string]struct {
 		input struct {
-			nodeId p2p.NodeId
+			PeerId p2p.PeerId
 			block  MockBlock
 		}
 		err error
 	}{
 		"success: request block": {
 			input: struct {
-				nodeId p2p.NodeId
+				PeerId p2p.PeerId
 				block  MockBlock
 			}{
-				nodeId: p2p.NodeId{
+				PeerId: p2p.PeerId{
 					Id: "1",
 				},
 				block: MockBlock{
@@ -147,10 +147,10 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		},
 		"fail: empty node id": {
 			input: struct {
-				nodeId p2p.NodeId
+				PeerId p2p.PeerId
 				block  MockBlock
 			}{
-				nodeId: p2p.NodeId{},
+				PeerId: p2p.PeerId{},
 				block: MockBlock{
 					seal: []byte("seal"),
 				},
@@ -159,10 +159,10 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 		},
 		"fail: empty block seal": {
 			input: struct {
-				nodeId p2p.NodeId
+				PeerId p2p.PeerId
 				block  MockBlock
 			}{
-				nodeId: p2p.NodeId{
+				PeerId: p2p.PeerId{
 					"1",
 				},
 				block: MockBlock{
@@ -185,7 +185,7 @@ func TestGrpcCommandService_ResponseBlock(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
-		err := GrpcCommandService.ResponseBlock(test.input.nodeId, test.input.block)
+		err := GrpcCommandService.ResponseBlock(test.input.PeerId, test.input.block)
 		assert.Equal(t, err, test.err)
 	}
 


### PR DESCRIPTION
1. 기존에 test파일에 **mock을 사용했던 것에서, 사용하지 않는 것으로 수정**했습니다.
mock이 필요한 때를 잘 모르고 써서 불필요하게 쓴 것 같습니다.
RequestBlock이나 ResponseBlock이 다른 구조체의 함수 실행 결과에 영향을 받지 않기 때문에 mock을 사용하지 않는 방향으로 바꿨습니다.

2. 테스트 인풋에 사용하는 block의 형식은 block 인터페이스에서 실제 구조체인 **yggdrasill/impl/default_block으로** 바꿨습니다.