### PR TITLE
Feature/consensus/doc

### DIFF
--- a/consensus/README.md
+++ b/consensus/README.md
@@ -62,3 +62,7 @@ Consensus Module에서 다루는 핵심 데이터
 ## Publish Command
 
 - BlockCreateCommand
+- ConsensusMsgSendCommand
+  - PreprepareMsg (leader)
+  - PrepareMsg
+  - CommitMsg

--- a/consensus/README.md
+++ b/consensus/README.md
@@ -21,25 +21,44 @@ Consensus Module에서 다루는 핵심 데이터
   - PreprepareMsg
   - PrepareMsg
   - CommitMsg
-- Paliament(P2P Network의 구성원)
+- Parliament(P2P Network의 구성원)
 
 
 
 ## Consume Event
 
 - Parliament변경
-  - LeaderChangeEvent
-  -  PeerConnectEvent
-  -  PeerDisConnectEvent
-- 합의할 Block 준비완료
-- ConsensusMessageArriveEvent(3 type)
+  - LeaderChangedEvent
+  - MemberJoinedEvent
+  - MemberRemovedEvent
+- Block 저장 완료
+
+
+
+
+## Publish Event
+
+- Consensus 관련
+  - ConsensusStartEvent (Preprepare Msg를 받았을 때)
+  - ConsensusPreparedEvent (Prepare Msg를 보냈을 때)
+  - ConsensusCommittedEvent (Commit Msg를 보냈을 때)
+  - ConsensusFinishedEvent (블록을 저장했을 때)
+- ConsensusMessageAddedEvent(3 type)
   - PreprepareMsg
   - PrepareMsg
   - CommitMsg
 
 
 
-## Publish Event
+## Consume Command
 
-- BlockConfirmEvent
-- ConsensusMessagePublishEvent
+- PreprepareMsg 받음
+- PrepareMsg 받음
+- CommitMsg 받음
+
+
+
+
+## Publish Command
+
+- BlockCreateCommand


### PR DESCRIPTION
consensus의 event와 command를 정리하기 위해 README.md 를 수정했습니다!

1. Consume event
- parliament 관련
parliament가 변경된 event를 consume합니다.
parliament가 변경되는 event에는 leader 변경 / member join / member exit 이 있습니다.
- Block 관련
합의된 block을 blockchain에 저장했다는 event를 consume합니다.
consensus의 state를 IDLE 로 변경합니다.

2. Publish event
- consensus 관련
consensus의 state를 변경하는 event입니다.
state는 IDLE -> Preprepare -> Prepare -> Commit -> IDLE -> ... 순으로 반복됩니다.
- ConsensusMessageAddedEvent
consensus msg를 msg pool에 저장하는 event입니다.

3. Consume command
다른 member에게 consensus message를 받았을 때의 command 입니다.

4. Publish command
consensus message를 보내는 command와 합의가 끝난 block을 blockchain에 저장하는 command 입니다.