### PR TITLE
[blockchain] block propose command handler

### DIFF
--- a/blockchain/command.go
+++ b/blockchain/command.go
@@ -18,7 +18,6 @@ package blockchain
 
 import (
 	"github.com/it-chain/engine/icode"
-	"github.com/it-chain/engine/txpool"
 	"github.com/it-chain/midgard"
 )
 
@@ -30,12 +29,6 @@ type SyncUpdateCommand struct {
 type NodeUpdateCommand struct {
 	midgard.EventModel
 	Peer
-}
-
-type ProposeBlockCommand struct {
-	midgard.CommandModel
-	// TODO: Transaction이 너무 다름.
-	Transactions []txpool.Transaction
 }
 
 // consensus에서 합의된 블록이 넘어오면 block pool에 저장한다.

--- a/blockchain/infra/adapter/block_propose_command_handler.go
+++ b/blockchain/infra/adapter/block_propose_command_handler.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 It-chain
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package adapter
+
+import (
+	"github.com/it-chain/engine/blockchain"
+	"github.com/it-chain/engine/txpool"
+	"errors"
+	"log"
+)
+
+var ErrCommandTransactions = errors.New("command's transactions nil or have length of zero")
+var ErrTxHasMissingProperties = errors.New("Tx has missing properties")
+
+type BlockCreateApi interface {
+	CreateBlock(txList []blockchain.Transaction) error
+}
+
+type BlockProposeCommandHandler struct{
+	blockApi BlockCreateApi
+}
+
+func NewBlockProposeCommandHandler(blockApi BlockCreateApi) *BlockProposeCommandHandler{
+	return &BlockProposeCommandHandler{
+		blockApi: blockApi,
+	}
+}
+
+func (h *BlockProposeCommandHandler) HandleProposeBlockCommand(command blockchain.ProposeBlockCommand) {
+	if err := validateCommand(command); err != nil {
+		log.Fatal(err)
+		return
+	}
+	txList := command.Transactions
+
+	if err := validateTxList(txList); err != nil {
+		log.Fatal(err)
+		return
+	}
+
+	defaultTxList := convertTxList(txList)
+
+	if err := h.blockApi.CreateBlock(defaultTxList); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func validateCommand(command blockchain.ProposeBlockCommand) error {
+	txList := command.Transactions
+
+	if txList == nil || len(txList) == 0 {
+		return ErrCommandTransactions
+	}
+	return nil
+}
+
+func validateTxList(txList []txpool.Transaction) error {
+	var err error
+
+	for _, tx := range txList {
+		err = validateTx(tx)
+	}
+
+	return err
+}
+
+func validateTx(tx txpool.Transaction) error {
+	if tx.TxId == "" || tx.PublishPeerId == "" || tx.TimeStamp.IsZero() || tx.TxData.Jsonrpc == "" ||
+		tx.TxData.Method == "" || tx.TxData.Params.Function == "" || tx.TxData.Params.Args == nil {
+		return ErrTxHasMissingProperties
+	}
+	return nil
+}
+
+func convertTxList(txList []txpool.Transaction) []blockchain.Transaction {
+	defaultTxList := make([]blockchain.Transaction, 0)
+
+	for _, tx := range txList {
+		defaultTx := convertTx(tx)
+		defaultTxList = append(defaultTxList, defaultTx)
+	}
+
+	return defaultTxList
+}
+
+func convertTx(tx txpool.Transaction) blockchain.Transaction {
+	return &blockchain.DefaultTransaction{
+		ID: tx.GetID(),
+		Status: blockchain.Status(tx.TxStatus),
+		PeerID: tx.PublishPeerId,
+		Timestamp: tx.TimeStamp,
+		TxData: &blockchain.TxData{
+			Jsonrpc: tx.TxData.Jsonrpc,
+			Method: blockchain.TxDataType(tx.TxData.Method),
+			Params: blockchain.Params{
+				Function: tx.TxData.Params.Function,
+				Args: tx.TxData.Params.Args,
+			},
+		},
+	}
+}

--- a/blockchain/infra/adapter/block_propose_command_handler_test.go
+++ b/blockchain/infra/adapter/block_propose_command_handler_test.go
@@ -1,0 +1,117 @@
+package adapter_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/it-chain/engine/blockchain"
+	"github.com/it-chain/engine/blockchain/infra/adapter"
+	"github.com/it-chain/engine/blockchain/test/mock"
+	"github.com/it-chain/engine/common/command"
+	"github.com/it-chain/midgard"
+	"github.com/magiconair/properties/assert"
+)
+
+func TestBlockProposeCommandHandler_HandleProposeBlockCommand(t *testing.T) {
+	tests := map[string]struct {
+		input struct {
+			command command.ProposeBlock
+		}
+		err error
+	}{
+		"command with emtpy transactions test": {
+			input: struct {
+				command command.ProposeBlock
+			}{
+				command: command.ProposeBlock{
+					CommandModel: midgard.CommandModel{ID: "111"},
+					TxList:       nil,
+				},
+			},
+			err: adapter.ErrCommandTransactions,
+		},
+		"transactions which have length of 0 test": {
+			input: struct {
+				command command.ProposeBlock
+			}{
+				command: command.ProposeBlock{
+					CommandModel: midgard.CommandModel{ID: "111"},
+					TxList:       make([]command.ProposeBlockTx, 0),
+				},
+			},
+			err: adapter.ErrCommandTransactions,
+		},
+		"transactions which have missing properties test": {
+			input: struct {
+				command command.ProposeBlock
+			}{
+				command: command.ProposeBlock{
+					CommandModel: midgard.CommandModel{ID: "111"},
+					TxList: []command.ProposeBlockTx{
+						command.ProposeBlockTx{ID: "", PeerID: ""},
+					},
+				},
+			},
+			err: adapter.ErrTxHasMissingProperties,
+		},
+		"successfully pass txlist to block api": {
+			input: struct {
+				command command.ProposeBlock
+			}{
+				command: command.ProposeBlock{
+					CommandModel: midgard.CommandModel{ID: "111"},
+					TxList: []command.ProposeBlockTx{
+						command.ProposeBlockTx{
+							ID:        "1",
+							Status:    1,
+							PeerID:    "2",
+							TimeStamp: time.Now(),
+							Jsonrpc:   "123",
+							Method:    "invoke",
+							Function:  "function1",
+							Args:      []string{"arg1", "arg2"},
+							Signature: []byte{0x1},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	}
+
+	blockApi := mock.BlockApi{}
+	blockApi.CreateBlockFunc = func(txList []blockchain.Transaction) error {
+		tx := txList[0]
+		txContentBytes, _ := tx.GetContent()
+		content := struct {
+			ID        string
+			Status    blockchain.Status
+			PeerID    string
+			Timestamp time.Time
+			TxData    *blockchain.TxData
+		}{}
+		json.Unmarshal(txContentBytes, &content)
+
+		// then
+		assert.Equal(t, "1", tx.GetID())
+		assert.Equal(t, "2", content.PeerID)
+		assert.Equal(t, blockchain.Status(1), content.Status)
+		assert.Equal(t, "123", content.TxData.Jsonrpc)
+		assert.Equal(t, blockchain.Invoke, content.TxData.Method)
+		assert.Equal(t, "function1", content.TxData.Params.Function)
+		assert.Equal(t, []string{"arg1", "arg2"}, content.TxData.Params.Args)
+
+		return nil
+	}
+
+	commandHandler := adapter.NewBlockProposeCommandHandler(blockApi, "solo")
+
+	for testName, test := range tests {
+		t.Logf("running test case %s", testName)
+
+		err := commandHandler.HandleProposeBlockCommand(test.input.command)
+
+		assert.Equal(t, err, test.err)
+	}
+}

--- a/blockchain/infra/adapter/command_handler.go
+++ b/blockchain/infra/adapter/command_handler.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/it-chain/engine/blockchain"
+	"github.com/it-chain/engine/common/command"
 )
 
 var ErrBlockNil = errors.New("Block nil error")
@@ -40,7 +41,7 @@ func NewCommandHandler(blockApi BlockApi) *CommandHandler {
 }
 
 // txpool에서 받은 transactions들을 block으로 만들어서 consensus에 보내준다.
-func (h *CommandHandler) HandleProposeBlockCommand(command blockchain.ProposeBlockCommand) {
+func (h *CommandHandler) HandleProposeBlockCommand(command command.ProposeBlock) {
 	//rawTxList := command.Transactions
 	//
 	//txList, err := convertTxList(rawTxList)
@@ -57,7 +58,6 @@ func (h *CommandHandler) HandleProposeBlockCommand(command blockchain.ProposeBlo
 	// TODO: service는 api에서 호출되어야한다.
 	//dispatcher.SendBlockValidateCommand(block)
 }
-
 
 /// 합의된 block이 넘어오면 block pool에 저장한다.
 func (h *CommandHandler) HandleConfirmBlockCommand(command blockchain.ConfirmBlockCommand) error {

--- a/blockchain/infra/adapter/command_handler.go
+++ b/blockchain/infra/adapter/command_handler.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 
 	"github.com/it-chain/engine/blockchain"
-	"github.com/it-chain/engine/txpool"
 )
 
 var ErrBlockNil = errors.New("Block nil error")
@@ -59,10 +58,6 @@ func (h *CommandHandler) HandleProposeBlockCommand(command blockchain.ProposeBlo
 	//dispatcher.SendBlockValidateCommand(block)
 }
 
-// TODO: yggdrasill/impl/Transaction과 txpool/Transaction이 다름.
-func convertTxList(txList []txpool.Transaction) ([]blockchain.Transaction, error) {
-	return nil, nil
-}
 
 /// 합의된 block이 넘어오면 block pool에 저장한다.
 func (h *CommandHandler) HandleConfirmBlockCommand(command blockchain.ConfirmBlockCommand) error {

--- a/blockchain/service.go
+++ b/blockchain/service.go
@@ -26,7 +26,7 @@ type BlockQueryService interface {
 }
 
 type BlockQueryInnerService interface {
-	GetStagedBlockByHeight(height BlockHeight) (Block, error)
+	GetStagedBlockByHeight(height BlockHeight)(Block, error)
 	GetStagedBlockById(blockId string) (Block, error)
 	GetLastCommitedBlock() (Block, error)
 	GetCommitedBlockByHeight(height BlockHeight) (Block, error)

--- a/blockchain/service.go
+++ b/blockchain/service.go
@@ -26,7 +26,7 @@ type BlockQueryService interface {
 }
 
 type BlockQueryInnerService interface {
-	GetStagedBlockByHeight(height BlockHeight)(Block, error)
+	GetStagedBlockByHeight(height BlockHeight) (Block, error)
 	GetStagedBlockById(blockId string) (Block, error)
 	GetLastCommitedBlock() (Block, error)
 	GetCommitedBlockByHeight(height BlockHeight) (Block, error)

--- a/blockchain/test/mock/mock_api.go
+++ b/blockchain/test/mock/mock_api.go
@@ -21,6 +21,7 @@ import "github.com/it-chain/engine/blockchain"
 type BlockApi struct {
 	AddBlockToPoolFunc            func(block blockchain.Block) error
 	CheckAndSaveBlockFromPoolFunc func(height blockchain.BlockHeight) error
+	CreateBlockFunc               func(txList []blockchain.Transaction) error
 }
 
 func (api BlockApi) AddBlockToPool(block blockchain.Block) error {
@@ -29,6 +30,10 @@ func (api BlockApi) AddBlockToPool(block blockchain.Block) error {
 
 func (api BlockApi) CheckAndSaveBlockFromPool(height blockchain.BlockHeight) error {
 	return api.CheckAndSaveBlockFromPoolFunc(height)
+}
+
+func (api BlockApi) CreateBlock(txList []blockchain.Transaction) error {
+	return api.CreateBlockFunc(txList)
 }
 
 type MockSyncBlockApi struct {

--- a/common/command/command.go
+++ b/common/command/command.go
@@ -157,16 +157,18 @@ type ReturnBlockResult struct {
 // Blockchain에게 block 생성 command
 type ProposeBlock struct {
 	midgard.CommandModel
-	TxList []struct {
-		ID        string
-		Status    int
-		PeerID    string
-		TimeStamp time.Time
-		Jsonrpc   string
-		Method    string
-		Type      int
-		Function  string
-		Args      []string
-		Signature []byte
-	}
+	TxList []ProposeBlockTx
+}
+
+type ProposeBlockTx struct {
+	ID        string
+	Status    int
+	PeerID    string
+	TimeStamp time.Time
+	Jsonrpc   string
+	Method    string
+	Type      int
+	Function  string
+	Args      []string
+	Signature []byte
 }


### PR DESCRIPTION
#425 
HandleBlockProposeCommand하는 일은 다음과 같습니다.

1. command에 데이터가 제대로 들어있나 확인.
2. txpool transactions을 blockchain transactions로 바꾸기 전에 데이터가 들어있나 확인합니다.
3. txpool transactions을 blockchain transactions로 바꿉니다.
4. block api의 CreateBlock으로 전달합니다. 