### PR TITLE
Changed the factory name from ConstructConsensus to BuildState.

### DIFF
--- a/consensus/pbft/state_factory.go
+++ b/consensus/pbft/state_factory.go
@@ -21,7 +21,7 @@ import (
 )
 
 // leader
-func CreateConsensus(parliament []MemberID, block ProposedBlock) (*State, error) {
+func NewState(parliament []MemberID, block ProposedBlock) (*State, error) {
 	representatives, err := Elect(parliament)
 	if err != nil {
 		return &State{}, err
@@ -40,7 +40,7 @@ func CreateConsensus(parliament []MemberID, block ProposedBlock) (*State, error)
 }
 
 // member
-func ConstructConsensus(msg PrePrepareMsg) (*State, error) {
+func BuildState(msg PrePrepareMsg) (*State, error) {
 	newState := &State{
 		StateID:         msg.StateID,
 		Representatives: msg.Representative,

--- a/consensus/pbft/state_factory_test.go
+++ b/consensus/pbft/state_factory_test.go
@@ -34,7 +34,7 @@ func TestCreateConsensus(t *testing.T) {
 	}
 
 	// when
-	c, err := pbft.CreateConsensus(p, b)
+	c, err := pbft.NewState(p, b)
 
 	// then
 	assert.Error(t, err)
@@ -43,7 +43,7 @@ func TestCreateConsensus(t *testing.T) {
 	p = append(p, l)
 	p = append(p, m)
 
-	c, err = pbft.CreateConsensus(p, b)
+	c, err = pbft.NewState(p, b)
 
 	// then
 	assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestConstructConsensus(t *testing.T) {
 	}
 
 	// when
-	c, err := pbft.ConstructConsensus(msg)
+	c, err := pbft.BuildState(msg)
 
 	// then
 	assert.NoError(t, err)


### PR DESCRIPTION
resolved: #686

details:

@junk-sound 님께서 말씀해주신 'ConstructConsensus가 의미를 잘 전달하지 못하는 issue'를 해결하였습니다.
construct 대신 build 라는 단어를 사용하기로 했고, consensus를 state로 대체하므로 factory함수명을 BuildState로 변경하였습니다.

 - [x] Test case
