### PR TITLE
[blockchain] remove blockchain query api

### DIFF
--- a/api_gateway/block_query_api.go
+++ b/api_gateway/block_query_api.go
@@ -21,238 +21,55 @@ import (
 	"github.com/it-chain/yggdrasill"
 
 	"errors"
-	"log"
 	"sync"
 
 	"time"
-
-	"bytes"
-
-	"encoding/hex"
 
 	"github.com/it-chain/engine/common/event"
 	"github.com/it-chain/leveldb-wrapper"
 )
 
-var ErrGetCommitedBlock = errors.New("Error in getting commited block")
-var ErrAddCommitingBlock = errors.New("Error in add block which is going to be commited")
+var ErrGetCommittedBlock = errors.New("Error in getting commited block")
+var ErrAddCommittingBlock = errors.New("Error in add block which is going to be commited")
 var ErrNewBlockStorage = errors.New("Error in construct block storage")
 var ErrNoCreatedBlock = errors.New("Error can not find created block")
 var ErrNoStagedBlock = errors.New("Error can not find staged block")
-var ErrNoBlock = errors.New("Error can not find block")
 var ErrInvalidStateBlock = errors.New("Error invalid state block")
 var ErrFailRemoveBlock = errors.New("Error failed removing block")
-var ErrFailBlockTypeCasting = errors.New("Error failed type casting block")
 var ErrIdEmpty = errors.New("Error that seal is empty string")
 var ErrEmptyBlock = errors.New("Error empty block when getting block")
-var ErrCheckEmpty = errors.New("Error when checking repo empty")
 
 type BlockQueryApi struct {
-	blockPoolRepository     BlockPoolRepository
-	commitedBlockRepository CommitedBlockRepository
+	blockRepository BlockRepository
 }
 
-func NewBlockQueryApi(blockPoolRepo BlockPoolRepository, commitedBlockRepo CommitedBlockRepository) BlockQueryApi {
+func NewBlockQueryApi(blockRepo BlockRepository) BlockQueryApi {
 	return BlockQueryApi{
-		blockPoolRepository:     blockPoolRepo,
-		commitedBlockRepository: commitedBlockRepo,
+		blockRepository: blockRepo,
 	}
 }
 
-func (q BlockQueryApi) GetStagedBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error) {
-	return q.blockPoolRepository.FindStagedBlockByHeight(height)
-}
-func (q BlockQueryApi) GetStagedBlockById(blockId string) (blockchain.DefaultBlock, error) {
-	return q.blockPoolRepository.FindStagedBlockById(blockId)
+func (q BlockQueryApi) GetLastCommittedBlock() (blockchain.DefaultBlock, error) {
+	return q.blockRepository.FindLastBlock()
 }
 
-func (q BlockQueryApi) GetLastCommitedBlock() (blockchain.DefaultBlock, error) {
-	return q.commitedBlockRepository.FindLastBlock()
+func (q BlockQueryApi) GetCommittedBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error) {
+	return q.blockRepository.FindBlockByHeight(height)
 }
 
-func (q BlockQueryApi) GetCommitedBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error) {
-	return q.commitedBlockRepository.FindBlockByHeight(height)
-}
-
-type BlockPoolRepository interface {
-	SaveCreatedBlock(block blockchain.DefaultBlock) error
-	SaveStagedBlock(block blockchain.DefaultBlock) error
-	FindCreatedBlockById(id string) (blockchain.DefaultBlock, error)
-	FindStagedBlockById(id string) (blockchain.DefaultBlock, error)
-	FindStagedBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error)
-	FindFirstStagedBlock() (blockchain.DefaultBlock, error)
-	FindBlockById(id string) (blockchain.DefaultBlock, error)
-	RemoveBlockById(id string) error
-}
-
-type BlockPoolRepositoryImpl struct {
-	Blocks []blockchain.Block
-}
-
-func NewBlockPoolRepository() *BlockPoolRepositoryImpl {
-	return &BlockPoolRepositoryImpl{
-		Blocks: make([]blockchain.Block, 0),
-	}
-}
-
-func (r *BlockPoolRepositoryImpl) SaveCreatedBlock(block blockchain.DefaultBlock) error {
-	if block.State != blockchain.Created {
-		return ErrInvalidStateBlock
-	}
-
-	for i, b := range r.Blocks {
-		if isBlockSealEqualWith(b, block.GetSeal()) {
-			r.Blocks[i] = &block
-			return nil
-		}
-	}
-	r.Blocks = append(r.Blocks, &block)
-	return nil
-}
-
-func (r *BlockPoolRepositoryImpl) SaveStagedBlock(block blockchain.DefaultBlock) error {
-	if block.State != blockchain.Staged {
-		return ErrInvalidStateBlock
-	}
-
-	for i, b := range r.Blocks {
-		if isBlockSealEqualWith(b, block.GetSeal()) {
-			r.Blocks[i] = &block
-			return nil
-		}
-	}
-	r.Blocks = append(r.Blocks, &block)
-	return nil
-}
-
-func (r *BlockPoolRepositoryImpl) FindCreatedBlockById(id string) (blockchain.DefaultBlock, error) {
-	for _, block := range r.Blocks {
-		if isBlockIdEqualWith(block, id) {
-			defaultBlock, ok := block.(*blockchain.DefaultBlock)
-			if !ok {
-				return blockchain.DefaultBlock{}, ErrFailBlockTypeCasting
-			}
-
-			if defaultBlock.State == blockchain.Created {
-				return *defaultBlock, nil
-			}
-		}
-	}
-	return blockchain.DefaultBlock{}, ErrNoCreatedBlock
-}
-
-func (r *BlockPoolRepositoryImpl) FindStagedBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error) {
-	for _, block := range r.Blocks {
-		if block.GetHeight() == height {
-			defaultBlock, ok := block.(*blockchain.DefaultBlock)
-			if !ok {
-				return blockchain.DefaultBlock{}, ErrFailBlockTypeCasting
-			}
-
-			if defaultBlock.State == blockchain.Staged {
-				return *defaultBlock, nil
-			}
-		}
-	}
-	return blockchain.DefaultBlock{}, ErrNoStagedBlock
-}
-
-func (r *BlockPoolRepositoryImpl) FindStagedBlockById(id string) (blockchain.DefaultBlock, error) {
-	for _, block := range r.Blocks {
-		if isBlockIdEqualWith(block, id) {
-
-			defaultBlock, ok := block.(*blockchain.DefaultBlock)
-			if !ok {
-				return blockchain.DefaultBlock{}, ErrFailBlockTypeCasting
-			}
-
-			if defaultBlock.State == blockchain.Staged {
-				return *defaultBlock, nil
-			}
-		}
-	}
-	return blockchain.DefaultBlock{}, ErrNoStagedBlock
-}
-
-func (r *BlockPoolRepositoryImpl) FindBlockById(id string) (blockchain.DefaultBlock, error) {
-	for _, block := range r.Blocks {
-		if isBlockIdEqualWith(block, id) {
-
-			defaultBlock, ok := block.(*blockchain.DefaultBlock)
-			if !ok {
-				return blockchain.DefaultBlock{}, ErrFailBlockTypeCasting
-			}
-
-			return *defaultBlock, nil
-		}
-	}
-
-	return blockchain.DefaultBlock{}, ErrNoBlock
-}
-
-func (r *BlockPoolRepositoryImpl) FindFirstStagedBlock() (blockchain.DefaultBlock, error) {
-	if len(r.Blocks) == 0 {
-		return blockchain.DefaultBlock{}, ErrNoStagedBlock
-	}
-
-	target := blockchain.DefaultBlock{}
-
-	for _, block := range r.Blocks {
-		defaultBlock, ok := block.(*blockchain.DefaultBlock)
-		if !ok {
-			return blockchain.DefaultBlock{}, ErrFailBlockTypeCasting
-		}
-
-		if stagedBlockWithSmallerHeight(target, *defaultBlock) {
-			target = *defaultBlock
-		}
-	}
-
-	if target.IsEmpty() {
-		return target, ErrNoStagedBlock
-	}
-
-	return target, nil
-}
-
-func stagedBlockWithSmallerHeight(base blockchain.DefaultBlock, comparator blockchain.DefaultBlock) bool {
-	return comparator.State == blockchain.Staged && (base.Height > comparator.Height || base.IsEmpty())
-}
-
-func (r *BlockPoolRepositoryImpl) RemoveBlockById(id string) error {
-	for i, b := range r.Blocks {
-		if isBlockIdEqualWith(b, id) {
-			r.Blocks = append(r.Blocks[:i], r.Blocks[i+1:]...)
-			return nil
-		}
-	}
-	return ErrFailRemoveBlock
-}
-
-func isBlockSealEqualWith(block blockchain.Block, seal []byte) bool {
-
-	return bytes.Equal(block.GetSeal(), seal)
-}
-
-func isBlockIdEqualWith(block blockchain.Block, id string) bool {
-	BlockID := hex.EncodeToString(block.GetSeal())
-
-	return BlockID == id
-}
-
-type CommitedBlockRepository interface {
+type BlockRepository interface {
 	Save(block blockchain.DefaultBlock) error
 	FindLastBlock() (blockchain.DefaultBlock, error)
 	FindBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error)
 	FindAllBlock() ([]blockchain.DefaultBlock, error)
 }
 
-type CommitedBlockRepositoryImpl struct {
+type BlockRepositoryImpl struct {
 	mux *sync.RWMutex
 	yggdrasill.BlockStorageManager
 }
 
-func NewCommitedBlockRepositoryImpl(dbPath string) (*CommitedBlockRepositoryImpl, error) {
+func NewBlockRepositoryImpl(dbPath string) (*BlockRepositoryImpl, error) {
 	validator := new(blockchain.DefaultValidator)
 	db := leveldbwrapper.CreateNewDB(dbPath)
 	opts := map[string]interface{}{}
@@ -262,62 +79,61 @@ func NewCommitedBlockRepositoryImpl(dbPath string) (*CommitedBlockRepositoryImpl
 		return nil, ErrNewBlockStorage
 	}
 
-	return &CommitedBlockRepositoryImpl{
+	return &BlockRepositoryImpl{
 		mux:                 &sync.RWMutex{},
 		BlockStorageManager: blockStorage,
 	}, nil
 }
 
-func (cbr *CommitedBlockRepositoryImpl) Save(block blockchain.DefaultBlock) error {
-	cbr.mux.Lock()
-	defer cbr.mux.Unlock()
+func (r *BlockRepositoryImpl) Save(block blockchain.DefaultBlock) error {
+	r.mux.Lock()
+	defer r.mux.Unlock()
 
-	err := cbr.BlockStorageManager.AddBlock(&block)
+	err := r.BlockStorageManager.AddBlock(&block)
 	if err != nil {
-		log.Fatal(err)
-		return ErrAddCommitingBlock
+		return ErrAddCommittingBlock
 	}
 
 	return nil
 }
 
-func (cbr *CommitedBlockRepositoryImpl) FindLastBlock() (blockchain.DefaultBlock, error) {
-	cbr.mux.Lock()
-	defer cbr.mux.Unlock()
+func (r *BlockRepositoryImpl) FindLastBlock() (blockchain.DefaultBlock, error) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
 
 	block := &blockchain.DefaultBlock{}
 
-	err := cbr.BlockStorageManager.GetLastBlock(block)
+	err := r.BlockStorageManager.GetLastBlock(block)
 	if err != nil {
-		return blockchain.DefaultBlock{}, ErrGetCommitedBlock
+		return blockchain.DefaultBlock{}, ErrGetCommittedBlock
 	}
 
 	return *block, nil
 }
-func (cbr *CommitedBlockRepositoryImpl) FindBlockByHeight(height uint64) (blockchain.DefaultBlock, error) {
-	cbr.mux.Lock()
-	defer cbr.mux.Unlock()
+func (r *BlockRepositoryImpl) FindBlockByHeight(height uint64) (blockchain.DefaultBlock, error) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
 
 	block := &blockchain.DefaultBlock{}
 
-	err := cbr.BlockStorageManager.GetBlockByHeight(block, height)
+	err := r.BlockStorageManager.GetBlockByHeight(block, height)
 	if err != nil {
-		return blockchain.DefaultBlock{}, ErrGetCommitedBlock
+		return blockchain.DefaultBlock{}, ErrGetCommittedBlock
 	}
 
 	return *block, nil
 }
 
-func (cbr *CommitedBlockRepositoryImpl) FindAllBlock() ([]blockchain.DefaultBlock, error) {
-	cbr.mux.Lock()
-	defer cbr.mux.Unlock()
+func (r *BlockRepositoryImpl) FindAllBlock() ([]blockchain.DefaultBlock, error) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
 
 	blocks := []blockchain.DefaultBlock{}
 
 	// set
 	lastBlock := &blockchain.DefaultBlock{}
 
-	err := cbr.BlockStorageManager.GetLastBlock(lastBlock)
+	err := r.BlockStorageManager.GetLastBlock(lastBlock)
 
 	if err != nil {
 		return nil, err
@@ -335,7 +151,7 @@ func (cbr *CommitedBlockRepositoryImpl) FindAllBlock() ([]blockchain.DefaultBloc
 
 		block := &blockchain.DefaultBlock{}
 
-		err := cbr.BlockStorageManager.GetBlockByHeight(block, i)
+		err := r.BlockStorageManager.GetBlockByHeight(block, i)
 
 		if err != nil {
 			return nil, err
@@ -352,66 +168,37 @@ func (cbr *CommitedBlockRepositoryImpl) FindAllBlock() ([]blockchain.DefaultBloc
 }
 
 type BlockEventListener struct {
-	blockPoolRepository     BlockPoolRepository
-	commitedBlockRepository CommitedBlockRepository
+	blockRepository BlockRepository
 }
 
-func NewBlockEventListener(blockPoolRepo BlockPoolRepository, commitedBlockRepo CommitedBlockRepository) BlockEventListener {
+func NewBlockEventListener(blockRepo BlockRepository) BlockEventListener {
 	return BlockEventListener{
-		blockPoolRepository:     blockPoolRepo,
-		commitedBlockRepository: commitedBlockRepo,
+		blockRepository: blockRepo,
 	}
 }
 
-func (l BlockEventListener) HandleBlockCreatedEvent(event event.BlockCreated) error {
-	block, err := createDefaultBlock(event.Seal, event.PrevSeal, event.Height, event.TxList, event.TxSeal, event.Timestamp, event.Creator, event.State)
-	if err != nil {
-		return err
-	}
-
-	l.blockPoolRepository.SaveCreatedBlock(block)
-
-	return nil
-}
-
-func (l BlockEventListener) HandleBlockStagedEvent(event event.BlockStaged) error {
-	blockID := event.ID
-	if blockID == "" {
-		return ErrIdEmpty
-	}
-
-	block, err := l.blockPoolRepository.FindCreatedBlockById(blockID)
-	if err != nil {
-		return err
-	}
-
-	block.State = event.State
-
-	err = l.blockPoolRepository.SaveStagedBlock(block)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (l BlockEventListener) HandleBlockCommitedEvent(event event.BlockCommitted) error {
+func (l BlockEventListener) HandleBlockCommittedEvent(event event.BlockCommitted) error {
 	blockID := event.ID
 
 	if blockID == "" {
 		return ErrIdEmpty
 	}
 
-	block, err := l.blockPoolRepository.FindBlockById(blockID)
-
-	block.State = event.State
-
-	err = l.commitedBlockRepository.Save(block)
+	block, err := createDefaultBlock(
+		event.Seal,
+		event.PrevSeal,
+		event.Height,
+		event.TxList,
+		event.TxSeal,
+		event.Timestamp,
+		event.Creator,
+		event.State,
+	)
 	if err != nil {
 		return err
 	}
 
-	err = l.blockPoolRepository.RemoveBlockById(blockID)
+	err = l.blockRepository.Save(block)
 	if err != nil {
 		return err
 	}

--- a/api_gateway/block_query_api_test.go
+++ b/api_gateway/block_query_api_test.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"testing"
 
-	"time"
-
 	"encoding/hex"
 
 	"github.com/it-chain/engine/api_gateway"
@@ -32,432 +30,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBlockQueryApi_GetStagedBlockByHeight(t *testing.T) {
-	pool := api_gateway.NewBlockPoolRepository()
-
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Created,
-	}
-	block2 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x2},
-		Height: blockchain.BlockHeight(2),
-		State:  blockchain.Staged,
-	}
-
-	pool.Blocks = append(pool.Blocks, block1)
-	pool.Blocks = append(pool.Blocks, block2)
-
-	// when
-	qa := api_gateway.NewBlockQueryApi(pool, nil)
-	// when
-	b1, err1 := qa.GetStagedBlockByHeight(1)
-	// then
-	assert.Equal(t, api_gateway.ErrNoStagedBlock, err1)
-	assert.Equal(t, blockchain.DefaultBlock{}, b1)
-
-	// when
-	b2, err2 := qa.GetStagedBlockByHeight(2)
-	// then
-	assert.Equal(t, nil, err2)
-	assert.Equal(t, []byte{0x2}, b2.GetSeal())
-	assert.Equal(t, blockchain.Staged, b2.State)
-	assert.Equal(t, blockchain.BlockHeight(2), b2.Height)
-}
-
-func TestBlockQueryApi_GetStagedBlockById(t *testing.T) {
-	pool := api_gateway.NewBlockPoolRepository()
-
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Created,
-	}
-	block2 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x2},
-		Height: blockchain.BlockHeight(2),
-		State:  blockchain.Staged,
-	}
-
-	pool.Blocks = append(pool.Blocks, block1)
-	pool.Blocks = append(pool.Blocks, block2)
-
-	// when
-	qa := api_gateway.NewBlockQueryApi(pool, nil)
-	// when
-	bId1 := hex.EncodeToString([]byte{0x1})
-	b1, err1 := qa.GetStagedBlockById(bId1)
-	// then
-	assert.Equal(t, api_gateway.ErrNoStagedBlock, err1)
-	assert.Equal(t, blockchain.DefaultBlock{}, b1)
-
-	// when
-	bId2 := hex.EncodeToString([]byte{0x2})
-	b2, err2 := qa.GetStagedBlockById(bId2)
-	// then
-	assert.Equal(t, nil, err2)
-	assert.Equal(t, []byte{0x2}, b2.GetSeal())
-	assert.Equal(t, blockchain.Staged, b2.State)
-	assert.Equal(t, blockchain.BlockHeight(2), b2.Height)
-}
-
-func TestBlockPoolRepositoryImpl_SaveCreatedBlock(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Created,
-	}
-	// when
-	err := bpr.SaveCreatedBlock(*block1)
-	// then
-	assert.Equal(t, nil, err)
-	assert.Equal(t, 1, len(bpr.Blocks))
-	assert.Equal(t, []byte{0x1}, bpr.Blocks[0].GetSeal())
-
-	// when
-	block2 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x2},
-		Height: blockchain.BlockHeight(2),
-		State:  blockchain.Staged,
-	}
-	// when
-	err2 := bpr.SaveCreatedBlock(*block2)
-	// then
-	assert.Equal(t, api_gateway.ErrInvalidStateBlock, err2)
-
-	// when
-	block3 := &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x5},
-		Height:   blockchain.BlockHeight(3),
-		State:    blockchain.Created,
-	}
-	// when
-	err3 := bpr.SaveCreatedBlock(*block3)
-	// then
-	assert.NoError(t, err3)
-	assert.Equal(t, 1, len(bpr.Blocks))
-
-	// when
-	block := bpr.Blocks[0]
-	// then
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x5}, block.GetPrevSeal())
-
-}
-
-func TestBlockPoolRepositoryImpl_SaveStagedBlock(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Staged,
-	}
-	// when
-	err := bpr.SaveStagedBlock(*block1)
-	// then
-	assert.Equal(t, nil, err)
-	assert.Equal(t, 1, len(bpr.Blocks))
-	assert.Equal(t, []byte{0x1}, bpr.Blocks[0].GetSeal())
-
-	// when
-	block2 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x2},
-		Height: blockchain.BlockHeight(2),
-		State:  blockchain.Created,
-	}
-	// when
-	err2 := bpr.SaveStagedBlock(*block2)
-	// then
-	assert.Equal(t, api_gateway.ErrInvalidStateBlock, err2)
-
-	// when
-	block3 := &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x5},
-		Height:   blockchain.BlockHeight(3),
-		State:    blockchain.Staged,
-	}
-	// when
-	err3 := bpr.SaveStagedBlock(*block3)
-	// then
-	assert.NoError(t, err3)
-	assert.Equal(t, 1, len(bpr.Blocks))
-
-	// when
-	block := bpr.Blocks[0]
-	// then
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x5}, block.GetPrevSeal())
-
-}
-
-func TestBlockPoolRepositoryImpl_FindCreatedBlockById(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Created,
-	})
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Staged,
-	})
-
-	// when
-	blockID := hex.EncodeToString([]byte{0x1})
-	block, err := bpr.FindCreatedBlockById(blockID)
-
-	// then
-	assert.Equal(t, err, nil)
-	assert.Equal(t, uint64(1), block.GetHeight())
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x1}, block.GetPrevSeal())
-
-	// when
-	_, err2 := bpr.FindCreatedBlockById(string([]byte{0x2}))
-
-	// then
-	assert.Equal(t, err2, api_gateway.ErrNoCreatedBlock)
-
-	// when
-	_, err3 := bpr.FindCreatedBlockById(string([]byte{0x3}))
-
-	// then
-	assert.Equal(t, err3, api_gateway.ErrNoCreatedBlock)
-
-}
-
-func TestBlockPoolRepositoryImpl_SaveCreatedBlock_InvalidStateBlock(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Committed,
-	}
-	// when
-	err := bpr.SaveCreatedBlock(*block1)
-
-	// then
-	assert.Equal(t, api_gateway.ErrInvalidStateBlock, err)
-	assert.Equal(t, 0, len(bpr.Blocks))
-}
-
-func TestBlockPoolRepositoryImpl_FindStagedBlockByHeight(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Staged,
-	})
-
-	// when
-	block, err := bpr.FindStagedBlockByHeight(1)
-
-	// then
-	assert.Equal(t, err, nil)
-	assert.Equal(t, uint64(1), block.GetHeight())
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x1}, block.GetPrevSeal())
-
-	// when
-	_, err2 := bpr.FindStagedBlockByHeight(133)
-
-	// then
-	assert.Equal(t, err2, api_gateway.ErrNoStagedBlock)
-}
-
-func TestBlockPoolRepositoryImpl_FindStagedBlockById(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Staged,
-	})
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Created,
-	})
-
-	// when
-	blockID := hex.EncodeToString([]byte{0x1})
-	block, err := bpr.FindStagedBlockById(blockID)
-
-	// then
-	assert.Equal(t, err, nil)
-	assert.Equal(t, uint64(1), block.GetHeight())
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x1}, block.GetPrevSeal())
-
-	// when
-	blockID2 := hex.EncodeToString([]byte{0x2})
-	_, err2 := bpr.FindStagedBlockById(blockID2)
-	// then
-	assert.Equal(t, err2, api_gateway.ErrNoStagedBlock)
-
-	// when
-	blockID3 := hex.EncodeToString([]byte{0x3})
-	_, err3 := bpr.FindStagedBlockById(blockID3)
-
-	// then
-	assert.Equal(t, err3, api_gateway.ErrNoStagedBlock)
-}
-
-func TestBlockPoolRepositoryImpl_FindFirstStagedBlock_basic(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Created,
-	})
-
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Staged,
-	})
-
-	// when
-	block, err := bpr.FindFirstStagedBlock()
-
-	assert.Equal(t, nil, err)
-	assert.Equal(t, uint64(2), block.Height)
-	assert.Equal(t, []byte{0x2}, block.Seal)
-}
-
-func TestBlockPoolRepositoryImpl_FindFirstStagedBlock_NoStagedBlockFound(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Created,
-	})
-
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Created,
-	})
-
-	// when
-	block, err := bpr.FindFirstStagedBlock()
-
-	assert.Equal(t, api_gateway.ErrNoStagedBlock, err)
-	assert.Equal(t, true, block.IsEmpty())
-}
-
-func TestBlockPoolRepositoryImpl_FindFirstStagedBlock_lenIsZero(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	block, err := bpr.FindFirstStagedBlock()
-
-	assert.Equal(t, api_gateway.ErrNoStagedBlock, err)
-	assert.Equal(t, uint64(0), block.Height)
-	assert.Equal(t, []byte(nil), block.Seal)
-}
-
-func TestBlockPoolRepositoryImpl_RemoveById(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Created,
-	})
-
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Created,
-	})
-
-	// when
-	bId1 := hex.EncodeToString([]byte{0x1})
-	err := bpr.RemoveBlockById(bId1)
-
-	// then
-	assert.Equal(t, nil, err)
-	assert.Equal(t, 1, len(bpr.Blocks))
-	assert.Equal(t, []byte{0x2}, bpr.Blocks[0].GetSeal())
-
-	// when
-	bId2 := hex.EncodeToString([]byte{0x3})
-	err2 := bpr.RemoveBlockById(bId2)
-
-	// then
-	assert.Equal(t, 1, len(bpr.Blocks))
-	assert.Equal(t, api_gateway.ErrFailRemoveBlock, err2)
-}
-
-func TestBlockPoolRepositoryImpl_RemoveById_FailRemoving(t *testing.T) {
-	bpr := api_gateway.NewBlockPoolRepository()
-
-	// when
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x1},
-		PrevSeal: []byte{0x1},
-		Height:   uint64(1),
-		State:    blockchain.Created,
-	})
-
-	bpr.Blocks = append(bpr.Blocks, &blockchain.DefaultBlock{
-		Seal:     []byte{0x2},
-		PrevSeal: []byte{0x2},
-		Height:   uint64(2),
-		State:    blockchain.Created,
-	})
-
-	// when
-	bId := hex.EncodeToString([]byte{0x3})
-	err := bpr.RemoveBlockById(bId)
-
-	// then
-	assert.Equal(t, 2, len(bpr.Blocks))
-	assert.Equal(t, api_gateway.ErrFailRemoveBlock, err)
-}
-
 func TestBlockQueryApi_FindLastCommitedBlock(t *testing.T) {
 	dbPath := "./.db"
 
 	// when
-	cbr, err := api_gateway.NewCommitedBlockRepositoryImpl(dbPath)
+	cbr, err := api_gateway.NewBlockRepositoryImpl(dbPath)
 	// then
 	assert.Equal(t, nil, err)
 
@@ -478,10 +55,10 @@ func TestBlockQueryApi_FindLastCommitedBlock(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 
-	blockQueryApi := api_gateway.NewBlockQueryApi(nil, cbr)
+	blockQueryApi := api_gateway.NewBlockQueryApi(cbr)
 
 	// when
-	block3, err := blockQueryApi.GetLastCommitedBlock()
+	block3, err := blockQueryApi.GetLastCommittedBlock()
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, block2.GetSeal(), block3.GetSeal())
@@ -493,7 +70,7 @@ func TestBlockQueryApi_FindCommitedBlockByHeight(t *testing.T) {
 	dbPath := "./.db"
 
 	// when
-	cbr, err := api_gateway.NewCommitedBlockRepositoryImpl(dbPath)
+	cbr, err := api_gateway.NewBlockRepositoryImpl(dbPath)
 	// then
 	assert.Equal(t, nil, err)
 
@@ -514,10 +91,10 @@ func TestBlockQueryApi_FindCommitedBlockByHeight(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 
-	blockQueryApi := api_gateway.NewBlockQueryApi(nil, cbr)
+	blockQueryApi := api_gateway.NewBlockQueryApi(cbr)
 
 	// when
-	block3, err := blockQueryApi.GetCommitedBlockByHeight(blockchain.BlockHeight(1))
+	block3, err := blockQueryApi.GetCommittedBlockByHeight(blockchain.BlockHeight(1))
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, block2.GetSeal(), block3.GetSeal())
@@ -529,7 +106,7 @@ func TestCommitedBlockRepositoryImpl(t *testing.T) {
 	dbPath := "./.db"
 
 	// when
-	cbr, err := api_gateway.NewCommitedBlockRepositoryImpl(dbPath)
+	cbr, err := api_gateway.NewBlockRepositoryImpl(dbPath)
 
 	// then
 	assert.Equal(t, nil, err)
@@ -551,10 +128,10 @@ func TestCommitedBlockRepositoryImpl(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 
-	blockQueryApi := api_gateway.NewBlockQueryApi(nil, cbr)
+	blockQueryApi := api_gateway.NewBlockQueryApi(cbr)
 
 	// when
-	block3, err := blockQueryApi.GetLastCommitedBlock()
+	block3, err := blockQueryApi.GetLastCommittedBlock()
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, block2.GetSeal(), block3.GetSeal())
@@ -570,111 +147,11 @@ func TestCommitedBlockRepositoryImpl(t *testing.T) {
 
 }
 
-func TestBlockEventListener_HandleBlockCreatedEvent(t *testing.T) {
-	blockpoolRepo := api_gateway.NewBlockPoolRepository()
-	eh := api_gateway.NewBlockEventListener(blockpoolRepo, nil)
-
-	event1 := event.BlockCreated{
-		EventModel: midgard.EventModel{
-			ID: "block_id1",
-		},
-		Seal:      []byte{0x1},
-		PrevSeal:  []byte{0x2},
-		Height:    uint64(3),
-		TxList:    mock.GetEventTxList(),
-		TxSeal:    [][]byte{{0x1}},
-		Timestamp: time.Now(),
-		Creator:   []byte{0x4},
-		State:     blockchain.Created,
-	}
-
-	// when
-	err := eh.HandleBlockCreatedEvent(event1)
-	// then
-	assert.Equal(t, err, nil)
-	assert.Equal(t, 1, len(blockpoolRepo.Blocks))
-
-	// when
-	block := blockpoolRepo.Blocks[0]
-	// then
-	assert.Equal(t, []byte{0x1}, block.GetSeal())
-	assert.Equal(t, []byte{0x2}, block.GetPrevSeal())
-	assert.Equal(t, uint64(3), block.GetHeight())
-	assert.Equal(t, blockchain.Created, (*block.(*blockchain.DefaultBlock)).State)
-	assert.Equal(t, "1", block.GetTxList()[0].GetID())
-	assert.Equal(t, []byte{0x4}, block.GetTxList()[0].GetSignature())
-}
-
-func TestBlockEventListener_HandleBlockStagedEvent(t *testing.T) {
-	blockpoolRepo := api_gateway.NewBlockPoolRepository()
-	eh := api_gateway.NewBlockEventListener(blockpoolRepo, nil)
-
-	// when
-	block1 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x1},
-		Height: blockchain.BlockHeight(1),
-		State:  blockchain.Created,
-	}
-	block2 := &blockchain.DefaultBlock{
-		Seal:   []byte{0x2},
-		Height: blockchain.BlockHeight(2),
-		State:  blockchain.Staged,
-	}
-
-	blockpoolRepo.SaveCreatedBlock(*block1)
-	blockpoolRepo.SaveCreatedBlock(*block2)
-
-	// when
-	block1ID := hex.EncodeToString([]byte{0x1})
-	event1 := event.BlockStaged{
-		EventModel: midgard.EventModel{
-			ID: block1ID,
-		},
-		State: blockchain.Staged,
-	}
-	err1 := eh.HandleBlockStagedEvent(event1)
-	// then
-	assert.NoError(t, err1)
-
-	// when
-	defaultBlock, err2 := blockpoolRepo.FindStagedBlockById(block1ID)
-	// then
-	assert.NoError(t, err2)
-	assert.Equal(t, []byte{0x1}, defaultBlock.Seal)
-	assert.Equal(t, uint64(1), defaultBlock.Height)
-
-	// when
-	block2ID := hex.EncodeToString([]byte{0x2})
-	event2 := event.BlockStaged{
-		EventModel: midgard.EventModel{
-			ID: block2ID,
-		},
-		State: blockchain.Staged,
-	}
-	err3 := eh.HandleBlockStagedEvent(event2)
-	// then
-	assert.Equal(t, api_gateway.ErrNoCreatedBlock, err3)
-
-	// when
-	block3ID := hex.EncodeToString([]byte{0x3})
-	event3 := event.BlockStaged{
-		EventModel: midgard.EventModel{
-			ID: block3ID,
-		},
-		State: blockchain.Staged,
-	}
-	err4 := eh.HandleBlockStagedEvent(event3)
-	// then
-	assert.Equal(t, api_gateway.ErrNoCreatedBlock, err4)
-
-}
-
 func TestBlockEventListener_HandleBlockCommitedEvent(t *testing.T) {
 	dbPath := "./.db"
 
 	// when
-	poolRepo := api_gateway.NewBlockPoolRepository()
-	cbr, err := api_gateway.NewCommitedBlockRepositoryImpl(dbPath)
+	cbr, err := api_gateway.NewBlockRepositoryImpl(dbPath)
 	// then
 	assert.Equal(t, nil, err)
 
@@ -689,23 +166,29 @@ func TestBlockEventListener_HandleBlockCommitedEvent(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 
-	eh := api_gateway.NewBlockEventListener(poolRepo, cbr)
+	eh := api_gateway.NewBlockEventListener(cbr)
 
 	// when
 	block2 := mock.GetNewBlock(block1.GetSeal(), 1)
-	block2.State = blockchain.Staged
-	// when
-	poolRepo.Blocks = append(poolRepo.Blocks, block2)
 	// when
 	block2ID := hex.EncodeToString(block2.GetSeal())
+	txList, _ := convertToTxList(block2.TxList)
+
 	event1 := event.BlockCommitted{
 		EventModel: midgard.EventModel{
 			ID: block2ID,
 		},
-		State: blockchain.Committed,
+		Seal:      block2.Seal,
+		PrevSeal:  block2.PrevSeal,
+		Height:    block2.Height,
+		TxList:    txList,
+		TxSeal:    block2.TxSeal,
+		Timestamp: block2.Timestamp,
+		Creator:   block2.Creator,
+		State:     blockchain.Committed,
 	}
 	// when - Handle BlockCommited event
-	err1 := eh.HandleBlockCommitedEvent(event1)
+	err1 := eh.HandleBlockCommittedEvent(event1)
 	// then
 	assert.NoError(t, err1)
 
@@ -715,11 +198,31 @@ func TestBlockEventListener_HandleBlockCommitedEvent(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.Equal(t, block3.Seal, block2.GetSeal())
 	assert.Equal(t, blockchain.Committed, block3.State)
+}
 
-	// when - Test whether target block is removed from block pool
-	block4, err3 := poolRepo.FindStagedBlockById(block2ID)
-	// then
-	assert.Equal(t, api_gateway.ErrNoStagedBlock, err3)
-	assert.Equal(t, true, block4.IsEmpty())
+func convertToTxList(txlist []*blockchain.DefaultTransaction) ([]event.Tx, error) {
+	defaultTxList := make([]event.Tx, 0)
 
+	for _, tx := range txlist {
+		defaultTx, err := convertToTx(tx)
+		if err != nil {
+			return defaultTxList, err
+		}
+		defaultTxList = append(defaultTxList, defaultTx)
+	}
+
+	return defaultTxList, nil
+}
+
+func convertToTx(tx *blockchain.DefaultTransaction) (event.Tx, error) {
+	return event.Tx{
+		ID:        tx.ID,
+		ICodeID:   tx.ICodeID,
+		PeerID:    tx.PeerID,
+		TimeStamp: tx.Timestamp,
+		Jsonrpc:   tx.Jsonrpc,
+		Function:  tx.Function,
+		Args:      tx.Args,
+		Signature: tx.Signature,
+	}, nil
 }

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -32,7 +32,7 @@ import (
 func makeFindCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 
-		blocks, err := b.commitedBlockRepository.FindAllBlock()
+		blocks, err := b.blockRepository.FindAllBlock()
 
 		if err != nil {
 			return nil, err

--- a/it-chain.go
+++ b/it-chain.go
@@ -139,15 +139,14 @@ func initApiGateway(config *conf.Configuration, errs chan error) func() {
 
 	// set blockchain
 	blockchainDB := "./api-db/block"
-	BlockPoolRepo := api_gateway.NewBlockPoolRepository()
-	CommittedBlockRepo, err := api_gateway.NewCommitedBlockRepositoryImpl(blockchainDB)
+	CommittedBlockRepo, err := api_gateway.NewBlockRepositoryImpl(blockchainDB)
 	if err != nil {
 		logger.Panic(&logger.Fields{"err_msg": err.Error()}, "error while init gateway")
 		panic(err)
 	}
 
-	blockQueryApi := api_gateway.NewBlockQueryApi(BlockPoolRepo, CommittedBlockRepo)
-	blockEventListener := api_gateway.NewBlockEventListener(BlockPoolRepo, CommittedBlockRepo)
+	blockQueryApi := api_gateway.NewBlockQueryApi(CommittedBlockRepo)
+	blockEventListener := api_gateway.NewBlockEventListener(CommittedBlockRepo)
 
 	// set ivm
 	icodeDB := "./api-db/ivm"


### PR DESCRIPTION
resolved: #641

details:

이벤트 소싱이 없어지면서, 그리고 각 컴포넌트 내부에 repository를 두기로 결정하면서 blockchain query api 부분에는 commited된, 즉 최종 확정된 블록들만 저장하면됩니다. 그래서 blockpool repository가 더이상 필요없어지고 created, staged 블록을 따로 저장할 필요도 없어졌습니다.
그래서 변화된 구조에서 필요없는 코드들을 삭제하려고합니다.

* blockpool repository 삭제
* BlockRepository 네이밍 변경
* committed 영문 오타 수정
* test case 삭제 및 바뀐 코드에 맞춰서 수정
* log fatal 삭제
- [x] Test case
