### PR TITLE
[blockchain] create proposed block

### DIFF
--- a/blockchain/api/block_api.go
+++ b/blockchain/api/block_api.go
@@ -97,7 +97,7 @@ func (api BlockApi) CreateProposedBlock(txList []*blockchain.DefaultTransaction)
 		return err
 	}
 
-	return api.consensusService.ConsensusBlock(proposedBlock)
+	return api.consensusService.ConsentBlock(proposedBlock)
 }
 
 func (bApi BlockApi) CommitProposedBlock(txList []*blockchain.DefaultTransaction) error {

--- a/blockchain/api/block_api.go
+++ b/blockchain/api/block_api.go
@@ -25,18 +25,16 @@ import (
 )
 
 type BlockApi struct {
-	publisherId      string
-	blockRepository  blockchain.BlockRepository
-	eventService     blockchain.EventService
-	consensusService blockchain.ConsensusService
+	publisherId     string
+	blockRepository blockchain.BlockRepository
+	eventService    blockchain.EventService
 }
 
-func NewBlockApi(publisherId string, blockRepository blockchain.BlockRepository, eventService blockchain.EventService, consensusService blockchain.ConsensusService) (BlockApi, error) {
+func NewBlockApi(publisherId string, blockRepository blockchain.BlockRepository, eventService blockchain.EventService) (BlockApi, error) {
 	return BlockApi{
-		publisherId:      publisherId,
-		blockRepository:  blockRepository,
-		eventService:     eventService,
-		consensusService: consensusService,
+		publisherId:     publisherId,
+		blockRepository: blockRepository,
+		eventService:    eventService,
 	}, nil
 }
 
@@ -89,22 +87,11 @@ func (bApi BlockApi) CommitGenesisBlock(GenesisConfPath string) error {
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }
 
-func (api BlockApi) CreateProposedBlock(txList []*blockchain.DefaultTransaction) error {
-	logger.Info(nil, "[Blockchain] Creating proposed block")
-
-	proposedBlock, err := api.createBlock(txList)
-	if err != nil {
-		return err
-	}
-
-	return api.consensusService.ConsentBlock(proposedBlock)
-}
-
 func (bApi BlockApi) CommitProposedBlock(txList []*blockchain.DefaultTransaction) error {
 	logger.Info(nil, "[Blockchain] Committing proposed block")
 
 	// create
-	ProposedBlock, err := bApi.createBlock(txList)
+	ProposedBlock, err := bApi.CreateProposedBlock(txList)
 	if err != nil {
 		return err
 	}
@@ -130,7 +117,7 @@ func (bApi BlockApi) CommitProposedBlock(txList []*blockchain.DefaultTransaction
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }
 
-func (api BlockApi) createBlock(txList []*blockchain.DefaultTransaction) (blockchain.DefaultBlock, error) {
+func (api BlockApi) CreateProposedBlock(txList []*blockchain.DefaultTransaction) (blockchain.DefaultBlock, error) {
 	lastBlock, err := api.blockRepository.FindLast()
 	if err != nil {
 		return blockchain.DefaultBlock{}, ErrGetLastBlock

--- a/blockchain/api/block_api.go
+++ b/blockchain/api/block_api.go
@@ -87,32 +87,26 @@ func (bApi BlockApi) CommitGenesisBlock(GenesisConfPath string) error {
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }
 
-func (bApi BlockApi) CommitProposedBlock(txList []*blockchain.DefaultTransaction) error {
+func (bApi BlockApi) CommitBlock(block blockchain.DefaultBlock) error {
 	logger.Info(nil, "[Blockchain] Committing proposed block")
 
-	// create
-	ProposedBlock, err := bApi.CreateProposedBlock(txList)
-	if err != nil {
-		return err
-	}
-
 	// save(commit)
-	ProposedBlock.SetState(blockchain.Committed)
+	block.SetState(blockchain.Committed)
 
-	err = bApi.blockRepository.Save(ProposedBlock)
+	err := bApi.blockRepository.Save(block)
 
 	if err != nil {
 		return ErrSaveBlock
 	}
 
 	// publish
-	commitEvent, err := createBlockCommittedEvent(ProposedBlock)
+	commitEvent, err := createBlockCommittedEvent(block)
 
 	if err != nil {
 		return ErrCreateEvent
 	}
 
-	logger.Info(nil, fmt.Sprintf("[Blockchain] Proposed block has Committed - seal: [%x],  height: [%d]", ProposedBlock.Seal, ProposedBlock.Height))
+	logger.Info(nil, fmt.Sprintf("[Blockchain] Proposed block has Committed - seal: [%x],  height: [%d]", block.Seal, block.Height))
 
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }

--- a/blockchain/api/block_api_test.go
+++ b/blockchain/api/block_api_test.go
@@ -52,9 +52,8 @@ func TestBlockApi_AddBlockToPool(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
-	consensusService := mock.ConsensusService{}
 
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
@@ -80,10 +79,9 @@ func TestBlockApi_CheckAndSaveBlockFromPool(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
-	consensusService := mock.ConsensusService{}
 
 	// When
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
@@ -101,10 +99,9 @@ func TestBlockApi_SyncIsProgressing(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
-	consensusService := mock.ConsensusService{}
 
 	// when
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
 
 	// then
 	state := blockApi.SyncIsProgressing()
@@ -185,9 +182,7 @@ func TestBlockApi_CommitProposedBlock(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	consensusService := mock.ConsensusService{}
-
-	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService, consensusService)
+	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService)
 
 	assert.NoError(t, err)
 
@@ -242,9 +237,7 @@ func TestBlockApi_CommitGenesisBlock(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	consensusService := mock.ConsensusService{}
-
-	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService, consensusService)
+	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService)
 	assert.NoError(t, err)
 
 	// when
@@ -267,21 +260,16 @@ func TestBlockApi_CreateProposedBlock(t *testing.T) {
 
 	eventService := mock.EventService{}
 
-	consensusService := mock.ConsensusService{}
-	consensusService.ConsensusBlockFunc = func(block blockchain.DefaultBlock) error {
-		assert.Equal(t, uint64(2), block.GetHeight())
-		assert.Equal(t, lastBlock.GetSeal(), block.GetPrevSeal())
-		assert.Equal(t, []byte("zf"), block.GetCreator())
-		return nil
-	}
-
-	blockApi, err := api.NewBlockApi(publisherID, blockRepo, eventService, consensusService)
+	blockApi, err := api.NewBlockApi(publisherID, blockRepo, eventService)
 	assert.NoError(t, err)
 
 	txList := mock.GetTxList(time.Now())
 
 	// when
-	err = blockApi.CreateProposedBlock(txList)
+	block, err := blockApi.CreateProposedBlock(txList)
+
 	// then
 	assert.NoError(t, err)
+	assert.Equal(t, lastBlock.GetSeal(), block.GetPrevSeal())
+	assert.Equal(t, uint64(2), block.GetHeight())
 }

--- a/blockchain/api/block_api_test.go
+++ b/blockchain/api/block_api_test.go
@@ -52,8 +52,9 @@ func TestBlockApi_AddBlockToPool(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
+	consensusService := mock.ConsensusService{}
 
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
@@ -79,9 +80,10 @@ func TestBlockApi_CheckAndSaveBlockFromPool(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
+	consensusService := mock.ConsensusService{}
 
 	// When
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
 
 	for testName, test := range tests {
 		t.Logf("running test case %s", testName)
@@ -99,9 +101,10 @@ func TestBlockApi_SyncIsProgressing(t *testing.T) {
 	publisherId := "zf"
 	blockRepo := mock.BlockRepository{}
 	eventService := mock.EventService{}
+	consensusService := mock.ConsensusService{}
 
 	// when
-	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService)
+	blockApi, _ := api.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
 
 	// then
 	state := blockApi.SyncIsProgressing()
@@ -182,7 +185,9 @@ func TestBlockApi_CommitProposedBlock(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService)
+	consensusService := mock.ConsensusService{}
+
+	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService, consensusService)
 
 	assert.NoError(t, err)
 
@@ -237,7 +242,9 @@ func TestBlockApi_CommitGenesisBlock(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService)
+	consensusService := mock.ConsensusService{}
+
+	bApi, err := api.NewBlockApi(publisherID, blockRepo, eventService, consensusService)
 	assert.NoError(t, err)
 
 	// when

--- a/blockchain/infra/adapter/block_propose_command_handler_test.go
+++ b/blockchain/infra/adapter/block_propose_command_handler_test.go
@@ -76,9 +76,7 @@ func TestBlockProposeCommandHandler_HandleProposeBlockCommand(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	consensusService := mock.ConsensusService{}
-
-	bApi, err := api.NewBlockApi(publisherID, br, eventService, consensusService)
+	bApi, err := api.NewBlockApi(publisherID, br, eventService)
 	assert.NoError(t, err)
 
 	commandHandler := adapter.NewBlockProposeCommandHandler(bApi, "solo")

--- a/blockchain/infra/adapter/block_propose_command_handler_test.go
+++ b/blockchain/infra/adapter/block_propose_command_handler_test.go
@@ -76,8 +76,9 @@ func TestBlockProposeCommandHandler_HandleProposeBlockCommand(t *testing.T) {
 
 	eventService := common.NewEventService("", "Event")
 
-	bApi, err := api.NewBlockApi(publisherID, br, eventService)
+	consensusService := mock.ConsensusService{}
 
+	bApi, err := api.NewBlockApi(publisherID, br, eventService, consensusService)
 	assert.NoError(t, err)
 
 	commandHandler := adapter.NewBlockProposeCommandHandler(bApi, "solo")

--- a/blockchain/infra/adapter/consensus_service.go
+++ b/blockchain/infra/adapter/consensus_service.go
@@ -1,0 +1,14 @@
+package adapter
+
+import "github.com/it-chain/engine/blockchain"
+
+type ConsensusService struct{}
+
+func NewConsensusService() *ConsensusService {
+	return &ConsensusService{}
+}
+
+// TODO
+func (s *ConsensusService) ConsentBlock(block blockchain.DefaultBlock) error {
+	return nil
+}

--- a/blockchain/service.go
+++ b/blockchain/service.go
@@ -19,3 +19,8 @@ package blockchain
 type EventService interface {
 	Publish(topic string, event interface{}) error
 }
+
+// TODO: should be implemented in infrastructure layer
+type ConsensusService interface {
+	ConsensusBlock(block DefaultBlock) error
+}

--- a/blockchain/service.go
+++ b/blockchain/service.go
@@ -22,5 +22,5 @@ type EventService interface {
 
 // TODO: should be implemented in infrastructure layer
 type ConsensusService interface {
-	ConsensusBlock(block DefaultBlock) error
+	ConsentBlock(block DefaultBlock) error
 }

--- a/blockchain/test/mock/mock_data.go
+++ b/blockchain/test/mock/mock_data.go
@@ -72,7 +72,7 @@ func GetStagedBlockWithId(blockId string) blockchain.DefaultBlock {
 		Seal:      []byte(blockId),
 		PrevSeal:  []byte{0x2},
 		Height:    blockchain.BlockHeight(1),
-		TxList:    getTxList(testingTime),
+		TxList:    GetTxList(testingTime),
 		TxSeal:    [][]byte{{0x1}},
 		Timestamp: testingTime,
 		Creator:   []byte("creator01"),
@@ -84,7 +84,7 @@ func GetNewBlock(prevSeal []byte, height uint64) *blockchain.DefaultBlock {
 	validator := &blockchain.DefaultValidator{}
 	testingTime := time.Now()
 	blockCreator := []byte("testUser")
-	txList := getTxList(testingTime)
+	txList := GetTxList(testingTime)
 	block := &blockchain.DefaultBlock{}
 	block.SetPrevSeal(prevSeal)
 	block.SetHeight(height)
@@ -102,7 +102,7 @@ func GetNewBlock(prevSeal []byte, height uint64) *blockchain.DefaultBlock {
 	return block
 }
 
-func getTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
+func GetTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
 	return []*blockchain.DefaultTransaction{
 		{
 			ID:        "tx01",
@@ -112,6 +112,7 @@ func getTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
 			Jsonrpc:   "jsonRPC01",
 			Function:  "function01",
 			Args:      []string{"arg1", "arg2"},
+			Signature: []byte("signature01"),
 		},
 		{
 
@@ -122,6 +123,7 @@ func getTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
 			Jsonrpc:   "jsonRPC02",
 			Function:  "function02",
 			Args:      []string{"arg1", "arg2"},
+			Signature: []byte("signature02"),
 		},
 		{
 			ID:        "tx03",
@@ -131,6 +133,7 @@ func getTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
 			Jsonrpc:   "jsonRPC03",
 			Function:  "function03",
 			Args:      []string{"arg1", "arg2"},
+			Signature: []byte("signature03"),
 		},
 		{
 			ID:        "tx04",
@@ -140,6 +143,7 @@ func getTxList(testingTime time.Time) []*blockchain.DefaultTransaction {
 			Jsonrpc:   "jsonRPC04",
 			Function:  "function04",
 			Args:      []string{"arg1", "arg2"},
+			Signature: []byte("signature04"),
 		},
 	}
 }

--- a/blockchain/test/mock/mock_service.go
+++ b/blockchain/test/mock/mock_service.go
@@ -72,3 +72,11 @@ type EventService struct {
 func (s EventService) Publish(topic string, event interface{}) error {
 	return s.PublishFunc(topic, event)
 }
+
+type ConsensusService struct {
+	ConsensusBlockFunc func(block blockchain.DefaultBlock) error
+}
+
+func (s ConsensusService) ConsensusBlock(block blockchain.DefaultBlock) error {
+	return s.ConsensusBlockFunc(block)
+}

--- a/blockchain/test/mock/mock_service.go
+++ b/blockchain/test/mock/mock_service.go
@@ -77,6 +77,6 @@ type ConsensusService struct {
 	ConsensusBlockFunc func(block blockchain.DefaultBlock) error
 }
 
-func (s ConsensusService) ConsensusBlock(block blockchain.DefaultBlock) error {
+func (s ConsensusService) ConsentBlock(block blockchain.DefaultBlock) error {
 	return s.ConsensusBlockFunc(block)
 }

--- a/it-chain.go
+++ b/it-chain.go
@@ -30,6 +30,7 @@ import (
 	blockchainApi "github.com/it-chain/engine/blockchain/api"
 	blockchainAdapter "github.com/it-chain/engine/blockchain/infra/adapter"
 	blockchainMem "github.com/it-chain/engine/blockchain/infra/mem"
+	"github.com/it-chain/engine/blockchain/test/mock"
 	"github.com/it-chain/engine/cmd/ivm"
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/logger"
@@ -257,7 +258,10 @@ func initBlockchain(config *conf.Configuration, server rpc.Server) func() {
 		panic(err)
 	}
 
-	blockProposeHandler := blockchainAdapter.NewBlockProposeCommandHandler(blockApi, config.Engine.Mode)
+	// TODO: Change with real consensus service
+	consensusService := mock.ConsensusService{}
+
+	blockProposeHandler := blockchainAdapter.NewBlockProposeCommandHandler(blockApi, consensusService, config.Engine.Mode)
 	server.Register("block.propose", blockProposeHandler.HandleProposeBlockCommand)
 
 	return func() {

--- a/it-chain.go
+++ b/it-chain.go
@@ -247,7 +247,8 @@ func initBlockchain(config *conf.Configuration, server rpc.Server) func() {
 	}
 
 	eventService := common.NewEventService(config.Engine.Amqp, "Event")
-	blockApi, err := blockchainApi.NewBlockApi(publisherId, blockRepo, eventService)
+	consensusService := blockchainAdapter.NewConsensusService()
+	blockApi, err := blockchainApi.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
 	if err != nil {
 		panic(err)
 	}

--- a/it-chain.go
+++ b/it-chain.go
@@ -247,8 +247,7 @@ func initBlockchain(config *conf.Configuration, server rpc.Server) func() {
 	}
 
 	eventService := common.NewEventService(config.Engine.Amqp, "Event")
-	consensusService := blockchainAdapter.NewConsensusService()
-	blockApi, err := blockchainApi.NewBlockApi(publisherId, blockRepo, eventService, consensusService)
+	blockApi, err := blockchainApi.NewBlockApi(publisherId, blockRepo, eventService)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
resolved: #720, #719 

details:

multi-mode에서는 proposed block command가 오면 바로 commit하는게 아니라 create를 해야합니다.
api/CreateProposedBlock에서 블럭을 생성하고 Consensus service로 보내게 됩니다.

+update
HandleProposeBlockCommand가 BlockApi와 너무 강하게 결합되있어서 같은 풀리퀘에 두 개 이슈에 관한 것을 올리게 되었습니다.

@junk-sound 님께서 피드백 해주신대로 로직을 추가해보았습니다. 코멘트 부탁드립니다

1. CreateProposedBlock 코드 작성
2. domain/ConsensusService interface 작성
3. 기존 테스트 코드 수정 
4. ProposeBlockHandler 

 - [x] Test case
