### PR TITLE
EngineConfiguration Mode Validation 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,9 @@ sample/db/test/*
 .tmp
 
 # vendor
+/vendor-new
 /vendor
+/.vendor-new
 
 # leveldb output
 *.log

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -45,6 +45,13 @@ type Configuration struct {
 	ApiGateway  model.ApiGatewayConfiguration
 }
 
+// EngineConfiguration Mode용
+var modeConsts = [...]string{
+	"solo",
+	"test",
+	"pbft",
+}
+
 // it-chain의 각종 설정을 받아온다.
 func SetConfigName(name string) {
 	instance.configName = name
@@ -70,8 +77,23 @@ func GetConfiguration() *Configuration {
 		if err != nil {
 			panic("error in read config")
 		}
+
+		if !HasValidMode(instance) {
+			panic("NewEngineConfiguration mode is wrong.")
+		}
 	})
 
 	// it-chain의 설정내용을 반환한다.
 	return instance
+}
+
+func HasValidMode(c *Configuration) bool {
+
+	for _, modeConst := range modeConsts {
+		if instance.Engine.Mode == modeConst {
+			return true
+		}
+	}
+	return false
+
 }

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -17,14 +17,63 @@
 package conf
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
-//todo : need testing code
+func TestHasValid(t *testing.T) {
+
+	isModeFalse := HasValidMode(instance)
+	assert.False(t, isModeFalse)
+
+}
+
 func TestGetConfiguration(t *testing.T) {
-	conf := GetConfiguration()
-	assert.Equal(t, conf.GrpcGateway.Address, "127.0.0.1")
-	assert.Equal(t, conf.Engine.Mode, "solo")
+
+	path := os.Getenv("GOPATH") + "/src/github.com/it-chain/engine/conf"
+	confFilename := "/config.yaml"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		os.Mkdir(path, os.ModePerm)
+	}
+
+	// yaml이라 탭말고 스페이스로 놔둬주세요 ㅠㅠ자동변환 하는 ide 쓰시는분들 유의 부탁드립니다(vs code 등)
+	ConfJson := []byte(`
+  engine:
+    logpath: log/it-chain.log
+    keypath: .it-chain/
+    mode: solo
+    amqp: amqp://guest:guest@localhost:5672/
+    bootstrapnodeaddress: 127.0.0.1:5555
+  txpool:
+    timeoutms: 1000
+    maxtransactionbyte: 1024
+  consensus:
+    batchtime: 3
+    maxtransactions: 100
+  blockchain:
+    genesisconfpath: ./Genesis.conf
+  peer:
+    leaderelection: RAFT
+  icode:
+    repositorypath: empty
+  grpcgateway:
+    address: 127.0.0.1
+    port: "13579"
+  apigateway:
+    address: 127.0.0.1
+    port: "4444"
+    `)
+
+	err := ioutil.WriteFile(path+confFilename, ConfJson, os.ModePerm)
+	assert.NoError(t, err)
+
+	config := GetConfiguration()
+	assert.Equal(t, config.GrpcGateway.Address, "127.0.0.1")
+	assert.Equal(t, config.Engine.Mode, "solo")
+
+	defer os.Remove(path + confFilename)
+
 }


### PR DESCRIPTION
resolved: #404 

details:

EngineConfiguration Mode를 한정하고 Mode외 설정시 panic  발생

[task detail...]

1. EngineConfiguration Mode를 solo, test, pbtf로 한정
2. 이외 발생시 panic 추가

 - [ ] Test case

* TestGetConfiguration이  todo로 되어있던데 작업중이신건지 모르겠네요.
* 커밋이 예전것도 같이 추가되는데 함께 리베이스를 해야 할 지...원 저장소와 비교해서 다른게 다 올려지는 듯 하여 8afe884 커밋만 pr이 안되어서 우선 올립니다.