### PR TITLE
Fix a typo in comment

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -1,4 +1,4 @@
-# Install and runing Tutorial
+# Install and running tutorial
 
  Currently only solo mode is supported.
 


### PR DESCRIPTION
Hello.

I corrected the typos.

Thanks.

Changes:

```
doc/TUTORIAL.md:1: runing -> "running"
```
