### PR TITLE
[consensus] service.go PropagateService 함수 인자 수정

### DIFF
--- a/consensus/pbft/api/state_api.go
+++ b/consensus/pbft/api/state_api.go
@@ -67,7 +67,7 @@ func (cApi *StateApiImpl) StartConsensus(proposedBlock pbft.ProposedBlock) error
 	}
 
 	createdPrePrepareMsg := pbft.NewPrePrepareMsg(createdState, cApi.publisherID)
-	if err := cApi.propagateService.BroadcastPrePrepareMsg(*createdPrePrepareMsg); err != nil {
+	if err := cApi.propagateService.BroadcastPrePrepareMsg(*createdPrePrepareMsg, createdState.Representatives); err != nil {
 		return err
 	}
 
@@ -96,7 +96,7 @@ func (cApi *StateApiImpl) HandlePrePrepareMsg(msg pbft.PrePrepareMsg) error {
 	}
 
 	prepareMsg := pbft.NewPrepareMsg(builtState, cApi.publisherID)
-	if err := cApi.propagateService.BroadcastPrepareMsg(*prepareMsg); err != nil {
+	if err := cApi.propagateService.BroadcastPrepareMsg(*prepareMsg, builtState.Representatives); err != nil {
 		return err
 	}
 	builtState.ToPrepareStage()
@@ -124,7 +124,7 @@ func (cApi *StateApiImpl) HandlePrepareMsg(msg pbft.PrepareMsg) error {
 	}
 
 	newCommitMsg := pbft.NewCommitMsg(&loadedState, cApi.publisherID)
-	if err := cApi.propagateService.BroadcastCommitMsg(*newCommitMsg); err != nil {
+	if err := cApi.propagateService.BroadcastCommitMsg(*newCommitMsg, loadedState.Representatives); err != nil {
 		return err
 	}
 	loadedState.ToCommitStage()

--- a/consensus/pbft/api/state_api_intenal_test.go
+++ b/consensus/pbft/api/state_api_intenal_test.go
@@ -189,13 +189,13 @@ func setUpApiCondition(isNeedConsensus bool, peerNum int, isNormalBlock bool,
 	}
 
 	propagateService := &mock.MockPropagateService{}
-	propagateService.BroadcastPrePrepareMsgFunc = func(msg pbft.PrePrepareMsg) error {
+	propagateService.BroadcastPrePrepareMsgFunc = func(msg pbft.PrePrepareMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
-	propagateService.BroadcastPrepareMsgFunc = func(msg pbft.PrepareMsg) error {
+	propagateService.BroadcastPrepareMsgFunc = func(msg pbft.PrepareMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
-	propagateService.BroadcastCommitMsgFunc = func(msg pbft.CommitMsg) error {
+	propagateService.BroadcastCommitMsgFunc = func(msg pbft.CommitMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
 

--- a/consensus/pbft/api/state_api_test.go
+++ b/consensus/pbft/api/state_api_test.go
@@ -283,13 +283,13 @@ func setUpApiCondition(isNeedConsensus bool, peerNum int, isRepoFull bool, isNor
 	}
 
 	propagateService := &mock.MockPropagateService{}
-	propagateService.BroadcastPrePrepareMsgFunc = func(msg pbft.PrePrepareMsg) error {
+	propagateService.BroadcastPrePrepareMsgFunc = func(msg pbft.PrePrepareMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
-	propagateService.BroadcastPrepareMsgFunc = func(msg pbft.PrepareMsg) error {
+	propagateService.BroadcastPrepareMsgFunc = func(msg pbft.PrepareMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
-	propagateService.BroadcastCommitMsgFunc = func(msg pbft.CommitMsg) error {
+	propagateService.BroadcastCommitMsgFunc = func(msg pbft.CommitMsg, representatives []*pbft.Representative) error {
 		return nil
 	}
 

--- a/consensus/pbft/service.go
+++ b/consensus/pbft/service.go
@@ -21,9 +21,9 @@ import "errors"
 var ErrNoParliamentMember = errors.New("No parliament member.")
 
 type PropagateService interface {
-	BroadcastPrePrepareMsg(msg PrePrepareMsg) error
-	BroadcastPrepareMsg(msg PrepareMsg) error
-	BroadcastCommitMsg(msg CommitMsg) error
+	BroadcastPrePrepareMsg(msg PrePrepareMsg, representatives []*Representative) error
+	BroadcastPrepareMsg(msg PrepareMsg, representatives []*Representative) error
+	BroadcastCommitMsg(msg CommitMsg, representatives []*Representative) error
 }
 
 type EventService interface {

--- a/consensus/pbft/test/mock/mock_service.go
+++ b/consensus/pbft/test/mock/mock_service.go
@@ -42,20 +42,20 @@ func (m MockConfirmService) ConfirmBlock(block pbft.ProposedBlock) error {
 }
 
 type MockPropagateService struct {
-	BroadcastPrepareMsgFunc    func(msg pbft.PrepareMsg) error
-	BroadcastPrePrepareMsgFunc func(msg pbft.PrePrepareMsg) error
-	BroadcastCommitMsgFunc     func(msg pbft.CommitMsg) error
+	BroadcastPrePrepareMsgFunc func(msg pbft.PrePrepareMsg, representatives []*pbft.Representative) error
+	BroadcastPrepareMsgFunc    func(msg pbft.PrepareMsg, representatives []*pbft.Representative) error
+	BroadcastCommitMsgFunc     func(msg pbft.CommitMsg, representatives []*pbft.Representative) error
 }
 
-func (m MockPropagateService) BroadcastPrepareMsg(msg pbft.PrepareMsg) error {
-	return m.BroadcastPrepareMsgFunc(msg)
+func (m MockPropagateService) BroadcastPrepareMsg(msg pbft.PrepareMsg, representatives []*pbft.Representative) error {
+	return m.BroadcastPrepareMsgFunc(msg, nil)
 }
 
-func (m MockPropagateService) BroadcastPrePrepareMsg(msg pbft.PrePrepareMsg) error {
-	return m.BroadcastPrePrepareMsgFunc(msg)
+func (m MockPropagateService) BroadcastPrePrepareMsg(msg pbft.PrePrepareMsg, representatives []*pbft.Representative) error {
+	return m.BroadcastPrePrepareMsgFunc(msg, nil)
 }
-func (m MockPropagateService) BroadcastCommitMsg(msg pbft.CommitMsg) error {
-	return m.BroadcastCommitMsgFunc(msg)
+func (m MockPropagateService) BroadcastCommitMsg(msg pbft.CommitMsg, representatives []*pbft.Representative) error {
+	return m.BroadcastCommitMsgFunc(msg, nil)
 }
 
 type MockParliamentService struct {


### PR DESCRIPTION
resolved issue : #763 

details : service.go PropogateService의 인터페이스와 그 구현체인 adapter/PropogateService.go 의 함수 인자가 달라서 DI를 하지 못하는 문제가 발생하여, 수정하였습니다. 함수타입 변경에 따라 StateApi도 수정하였습니다