### PR TITLE
[ivm] Add icode version when cloning #779

### DIFF
--- a/api_gateway/icode_query_api_test.go
+++ b/api_gateway/icode_query_api_test.go
@@ -49,7 +49,7 @@ func TestLevelDbMetaRepository_Save(t *testing.T) {
 				GitUrl:         "url",
 				Path:           "path",
 				CommitHash:     "hash",
-				Version:        ivm.Version{},
+				Version:        "version",
 			},
 			Output: nil,
 		},

--- a/common/event/event.go
+++ b/common/event/event.go
@@ -49,7 +49,7 @@ type ICodeCreated struct {
 	GitUrl         string
 	Path           string
 	CommitHash     string
-	Version        struct{}
+	Version        string
 }
 
 // ivm meta deleted

--- a/ivm/icode.go
+++ b/ivm/icode.go
@@ -16,9 +16,7 @@
 
 package ivm
 
-type Version struct {
-}
-
+type Version = string
 type ID = string
 type MetaStatus = int
 
@@ -31,7 +29,7 @@ type ICode struct {
 	Version        Version
 }
 
-func NewICode(id string, repositoryName string, gitUrl string, path string, commitHash string) ICode {
+func NewICode(id string, repositoryName string, gitUrl string, path string, commitHash string, version string) ICode {
 
 	return ICode{
 		ID:             id,
@@ -39,5 +37,6 @@ func NewICode(id string, repositoryName string, gitUrl string, path string, comm
 		Path:           path,
 		GitUrl:         gitUrl,
 		RepositoryName: repositoryName,
+		Version:		version,
 	}
 }

--- a/ivm/icode.go
+++ b/ivm/icode.go
@@ -37,6 +37,6 @@ func NewICode(id string, repositoryName string, gitUrl string, path string, comm
 		Path:           path,
 		GitUrl:         gitUrl,
 		RepositoryName: repositoryName,
-		Version:		version,
+		Version:        version,
 	}
 }

--- a/ivm/infra/git/icode_git_store.go
+++ b/ivm/infra/git/icode_git_store.go
@@ -32,8 +32,9 @@ import (
 var ErrUnsupportedUrl = errors.New("unsupported url [format: github.com/xxx/yyyy], currently only github url is supported")
 
 const (
-	github = "github.com"
-	gitlab = "gitlab.com"
+	github         = "github.com"
+	gitlab         = "gitlab.com"
+	defaultVersion = "1.0"
 )
 
 type RepositoryService struct {
@@ -88,14 +89,18 @@ func (gApi *RepositoryService) Clone(id string, baseSavePath string, repositoryU
 	}
 
 	lastHeadCommit, err := r.CommitObject(head.Hash())
-	commitHash := lastHeadCommit.Hash.String()
-
 	if err != nil {
 		return ivm.ICode{}, err
 	}
 
-	version := "1.0"
+	commitHash := lastHeadCommit.Hash.String()
+
+	version := defaultVersion
 	tags, err := r.Tags()
+	if err != nil {
+		return ivm.ICode{}, err
+	}
+
 	tags.ForEach(func(tag *plumbing.Reference) error {
 		if strings.Compare(tag.Hash().String(), head.Hash().String()) == 0 {
 			s := strings.Split(tag.Name().String(), "/")

--- a/ivm/infra/git/icode_git_store.go
+++ b/ivm/infra/git/icode_git_store.go
@@ -25,6 +25,7 @@ import (
 	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/ivm"
 	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 )
 
@@ -93,9 +94,19 @@ func (gApi *RepositoryService) Clone(id string, baseSavePath string, repositoryU
 		return ivm.ICode{}, err
 	}
 
-	logger.Info(nil, fmt.Sprintf("[IVM] ICode has successfully cloned - url: [%s], icodeID: [%s]", repositoryUrl, id))
+	version := "1.0"
+	tags, err := r.Tags()
+	tags.ForEach(func(tag *plumbing.Reference) error {
+		if strings.Compare(tag.Hash().String(), head.Hash().String()) == 0 {
+			s := strings.Split(tag.Name().String(), "/")
+			version = s[len(s)-1]
+		}
+		return nil
+	})
 
-	metaData := ivm.NewICode(id, name, repositoryUrl, baseSavePath+"/"+name, commitHash)
+	logger.Info(nil, fmt.Sprintf("[IVM] ICode has successfully cloned - url: [%s], icodeID: [%s], version[%s]", repositoryUrl, id, version))
+
+	metaData := ivm.NewICode(id, name, repositoryUrl, baseSavePath+"/"+name, commitHash, version)
 	return metaData, nil
 }
 

--- a/ivm/infra/git/icode_git_store_test.go
+++ b/ivm/infra/git/icode_git_store_test.go
@@ -48,7 +48,7 @@ func TestICodeGitStoreApi_Clone(t *testing.T) {
 		"success": {
 			ID:          "1",
 			InputGitURL: "github.com/junbeomlee/test_icode",
-			OutputMeta:  ivm.ICode{RepositoryName: "test_icode", GitUrl: "github.com/junbeomlee/test_icode", Path: baseTempPath + "/" + "test_icode"},
+			OutputMeta:  ivm.ICode{RepositoryName: "test_icode", GitUrl: "github.com/junbeomlee/test_icode", Path: baseTempPath + "/" + "test_icode", Version: "1.0"},
 			OutputErr:   nil,
 		},
 		"fail": {
@@ -99,7 +99,7 @@ func TestICodeGitStoreApi_CloneWithPassword(t *testing.T) {
 			ID:          "1",
 			InputGitURL: "github.com/nesticat/test_icode",
 			InputPwd:    "pwdtest",
-			OutputMeta:  ivm.ICode{RepositoryName: "test_icode", GitUrl: "github.com/nesticat/test_icode", Path: baseTempPath + "/" + "test_icode"},
+			OutputMeta:  ivm.ICode{RepositoryName: "test_icode", GitUrl: "github.com/nesticat/test_icode", Path: baseTempPath + "/" + "test_icode", Version: "1.0"},
 			OutputErr:   nil,
 		},
 		"fail": {


### PR DESCRIPTION
1. version 을 받아오는 go-git의 TagObject 함수가 정상동작하지 않아서, Tags 함수로 전체 tag를 가져와서 hash비교하는 방식으로 구현하였습니다. 
2. ICode Version 구조체를 string 으로 변경하였습니다.