### PR TITLE
Add codes for retrieving a block by ID

### DIFF
--- a/api_gateway/block_query_api.go
+++ b/api_gateway/block_query_api.go
@@ -57,10 +57,15 @@ func (q BlockQueryApi) GetCommittedBlockByHeight(height blockchain.BlockHeight) 
 	return q.blockRepository.FindBlockByHeight(height)
 }
 
+func (q BlockQueryApi) GetCommittedBlockBySeal(seal []byte) (blockchain.DefaultBlock, error) {
+	return q.blockRepository.FindBlockBySeal(seal)
+}
+
 type BlockRepository interface {
 	Save(block blockchain.DefaultBlock) error
 	FindLastBlock() (blockchain.DefaultBlock, error)
 	FindBlockByHeight(height blockchain.BlockHeight) (blockchain.DefaultBlock, error)
+	FindBlockBySeal(seal []byte) (blockchain.DefaultBlock, error)
 	FindAllBlock() ([]blockchain.DefaultBlock, error)
 }
 
@@ -117,6 +122,20 @@ func (r *BlockRepositoryImpl) FindBlockByHeight(height uint64) (blockchain.Defau
 	block := &blockchain.DefaultBlock{}
 
 	err := r.BlockStorageManager.GetBlockByHeight(block, height)
+	if err != nil {
+		return blockchain.DefaultBlock{}, ErrGetCommittedBlock
+	}
+
+	return *block, nil
+}
+
+func (r *BlockRepositoryImpl) FindBlockBySeal(seal []byte) (blockchain.DefaultBlock, error) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	block := &blockchain.DefaultBlock{}
+
+	err := r.BlockStorageManager.GetBlockBySeal(block, seal)
 	if err != nil {
 		return blockchain.DefaultBlock{}, ErrGetCommittedBlock
 	}

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -26,6 +26,7 @@ import (
 type Endpoints struct {
 	FindAllCommittedBlocksEndpoint     endpoint.Endpoint
 	FindCommittedBlockByHeightEndpoint endpoint.Endpoint
+	FindCommittedBlockBySealEndpoint   endpoint.Endpoint
 	FindAllMetaEndpoint                endpoint.Endpoint
 }
 
@@ -37,6 +38,7 @@ func MakeBlockchainEndpoints(b BlockQueryApi) Endpoints {
 	return Endpoints{
 		FindAllCommittedBlocksEndpoint:     makeFindAllCommittedBlocksEndpoint(b),
 		FindCommittedBlockByHeightEndpoint: makeFindCommittedBlockByHeightEndpoint(b),
+		FindCommittedBlockBySealEndpoint:   makeFindCommittedBlockBySealEndpoint(b),
 	}
 }
 
@@ -59,6 +61,19 @@ func makeFindAllCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 		}
 
 		return blocks, nil
+	}
+}
+
+func makeFindCommittedBlockBySealEndpoint(b BlockQueryApi) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(FindCommittedBlockByIdsRequest)
+		block, err := b.blockRepository.FindBlockBySeal(req.Seal)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return block, nil
 	}
 }
 

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -23,13 +23,33 @@ import (
 	"github.com/it-chain/engine/common/logger"
 )
 
-//This file is based on the following sample.
-// https://github.com/marcusolsson/goddd/blob/master/booking/endpoint.go
+type Endpoints struct {
+	FindAllCommittedBlocksEndpoint     endpoint.Endpoint
+	FindCommittedBlockByHeightEndpoint endpoint.Endpoint
+	FindAllMetaEndpoint                endpoint.Endpoint
+}
+
+/*
+ * returns endpoints
+ */
+
+func MakeBlockchainEndpoints(b BlockQueryApi) Endpoints {
+	return Endpoints{
+		FindAllCommittedBlocksEndpoint:     makeFindAllCommittedBlocksEndpoint(b),
+		FindCommittedBlockByHeightEndpoint: makeFindCommittedBlockByHeightEndpoint(b),
+	}
+}
+
+func MakeIvmEndpoints(i ICodeQueryApi) Endpoints {
+	return Endpoints{
+		FindAllMetaEndpoint: makeFindAllMetaEndpoint(i),
+	}
+}
 
 /*
  * blockchain
  */
-func makeFindCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
+func makeFindAllCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 
 		blocks, err := b.blockRepository.FindAllBlock()
@@ -39,6 +59,19 @@ func makeFindCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 		}
 
 		return blocks, nil
+	}
+}
+
+func makeFindCommittedBlockByHeightEndpoint(b BlockQueryApi) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(FindCommittedBlockByIdsRequest)
+		block, err := b.blockRepository.FindBlockByHeight(req.Height)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return block, nil
 	}
 }
 
@@ -52,4 +85,9 @@ func makeFindAllMetaEndpoint(i ICodeQueryApi) endpoint.Endpoint {
 		}
 		return metas, nil
 	}
+}
+
+type FindCommittedBlockByIdsRequest struct {
+	Height uint64
+	Seal   []byte
 }

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -24,10 +24,9 @@ import (
 )
 
 type Endpoints struct {
-	FindAllCommittedBlocksEndpoint     endpoint.Endpoint
-	FindCommittedBlockByHeightEndpoint endpoint.Endpoint
-	FindCommittedBlockBySealEndpoint   endpoint.Endpoint
-	FindAllMetaEndpoint                endpoint.Endpoint
+	FindAllCommittedBlocksEndpoint   endpoint.Endpoint
+	FindCommittedBlockBySealEndpoint endpoint.Endpoint
+	FindAllMetaEndpoint              endpoint.Endpoint
 }
 
 /*
@@ -36,9 +35,8 @@ type Endpoints struct {
 
 func MakeBlockchainEndpoints(b BlockQueryApi) Endpoints {
 	return Endpoints{
-		FindAllCommittedBlocksEndpoint:     makeFindAllCommittedBlocksEndpoint(b),
-		FindCommittedBlockByHeightEndpoint: makeFindCommittedBlockByHeightEndpoint(b),
-		FindCommittedBlockBySealEndpoint:   makeFindCommittedBlockBySealEndpoint(b),
+		FindAllCommittedBlocksEndpoint:   makeFindAllCommittedBlocksEndpoint(b),
+		FindCommittedBlockBySealEndpoint: makeFindCommittedBlockBySealEndpoint(b),
 	}
 }
 
@@ -53,39 +51,31 @@ func MakeIvmEndpoints(i ICodeQueryApi) Endpoints {
  */
 func makeFindAllCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-
-		blocks, err := b.blockRepository.FindAllBlock()
-
-		if err != nil {
-			return nil, err
+		if request == nil {
+			blocks, err := b.blockRepository.FindAllBlock()
+			if err != nil {
+				return nil, err
+			}
+			return blocks, nil
+			// when request is not nil, it means endponint takes attribute(params) as a request
+		} else {
+			req := request.(FindCommittedBlockByHeightRequest)
+			block, err := b.blockRepository.FindBlockByHeight(req.Height)
+			if err != nil {
+				return nil, err
+			}
+			return block, nil
 		}
-
-		return blocks, nil
 	}
 }
 
 func makeFindCommittedBlockBySealEndpoint(b BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(FindCommittedBlockByIdsRequest)
+		req := request.(FindCommittedBlockBySealRequest)
 		block, err := b.blockRepository.FindBlockBySeal(req.Seal)
-
 		if err != nil {
 			return nil, err
 		}
-
-		return block, nil
-	}
-}
-
-func makeFindCommittedBlockByHeightEndpoint(b BlockQueryApi) endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(FindCommittedBlockByIdsRequest)
-		block, err := b.blockRepository.FindBlockByHeight(req.Height)
-
-		if err != nil {
-			return nil, err
-		}
-
 		return block, nil
 	}
 }
@@ -102,7 +92,10 @@ func makeFindAllMetaEndpoint(i ICodeQueryApi) endpoint.Endpoint {
 	}
 }
 
-type FindCommittedBlockByIdsRequest struct {
+type FindCommittedBlockByHeightRequest struct {
 	Height uint64
-	Seal   []byte
+}
+
+type FindCommittedBlockBySealRequest struct {
+	Seal []byte
 }

--- a/it-chain.go
+++ b/it-chain.go
@@ -185,16 +185,16 @@ func initApiGateway(config *conf.Configuration, errs chan error) func() {
 		panic(err)
 	}
 
-	var h http.Handler
+	var handler http.Handler
 	{
-		h = api_gateway.BlockchainApiHandler(blockQueryApi, icodeQueryApi, httpLogger)
+		handler = api_gateway.NewApiHandler(blockQueryApi, icodeQueryApi, httpLogger)
 	}
 
 	http.Handle("/", mux)
 
 	go func() {
 		logger.Infof(nil, "[Main] Api-gateway is staring on port:%s", config.ApiGateway.Port)
-		errs <- http.ListenAndServe(ipAddress, h)
+		errs <- http.ListenAndServe(ipAddress, handler)
 	}()
 
 	return func() {

--- a/it-chain.go
+++ b/it-chain.go
@@ -185,13 +185,16 @@ func initApiGateway(config *conf.Configuration, errs chan error) func() {
 		panic(err)
 	}
 
-	mux.Handle("/blocks", api_gateway.BlockchainApiHandler(blockQueryApi, httpLogger))
-	mux.Handle("/icodes", api_gateway.ICodeApiHandler(icodeQueryApi, httpLogger))
+	var h http.Handler
+	{
+		h = api_gateway.BlockchainApiHandler(blockQueryApi, icodeQueryApi, httpLogger)
+	}
+
 	http.Handle("/", mux)
 
 	go func() {
 		logger.Infof(nil, "[Main] Api-gateway is staring on port:%s", config.ApiGateway.Port)
-		errs <- http.ListenAndServe(ipAddress, nil)
+		errs <- http.ListenAndServe(ipAddress, h)
 	}()
 
 	return func() {


### PR DESCRIPTION
* Descriptions
add codes for finding a particular block by block seal or block height (via HTTP request)

* Example usage 
    - by height 
        [GET] http://localhost:4444/blocks?height=0
    - by seal
        [GET] http://localhost:4444/blocks/532446bacbc662ef8e46a0c79bb10541f01e8f0fbccad55106141608c35f4b42


블록을 hash 또는 height를 이용하여 조회가능하도록 하였습니다.

**Issue**
[#794](https://github.com/it-chain/engine/issues/794)

**Component**
api_gateway