### PR TITLE
Add endpoints of connection query api

### DIFF
--- a/api_gateway/block_query_api.go
+++ b/api_gateway/block_query_api.go
@@ -43,8 +43,8 @@ type BlockQueryApi struct {
 	blockRepository BlockRepository
 }
 
-func NewBlockQueryApi(blockRepo BlockRepository) BlockQueryApi {
-	return BlockQueryApi{
+func NewBlockQueryApi(blockRepo BlockRepository) *BlockQueryApi {
+	return &BlockQueryApi{
 		blockRepository: blockRepo,
 	}
 }

--- a/api_gateway/connection_query_api.go
+++ b/api_gateway/connection_query_api.go
@@ -11,10 +11,10 @@ var ErrConnectionExists = errors.New("Connection already exists")
 
 type ConnectionQueryApi struct {
 	mux                  *sync.Mutex
-	connectionRepository ConnectionRepository
+	connectionRepository *ConnectionRepository
 }
 
-func NewConnectionQueryApi(connRepo ConnectionRepository) *ConnectionQueryApi {
+func NewConnectionQueryApi(connRepo *ConnectionRepository) *ConnectionQueryApi {
 	return &ConnectionQueryApi{
 		mux:                  &sync.Mutex{},
 		connectionRepository: connRepo,
@@ -91,11 +91,11 @@ func (cr *ConnectionRepository) FindByID(connID string) (Connection, error) {
 }
 
 type ConnectionEventListener struct {
-	connectionRepository ConnectionRepository
+	connectionRepository *ConnectionRepository
 }
 
-func NewConnectionEventListener(connRepo ConnectionRepository) ConnectionEventListener {
-	return ConnectionEventListener{
+func NewConnectionEventListener(connRepo *ConnectionRepository) *ConnectionEventListener {
+	return &ConnectionEventListener{
 		connectionRepository: connRepo,
 	}
 }

--- a/api_gateway/connection_query_api_test.go
+++ b/api_gateway/connection_query_api_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestConnectionQueryApi_GetAllConnectionList(t *testing.T) {
 	repo := api_gateway.NewConnectionRepository()
-	api := api_gateway.NewConnectionQueryApi(*repo)
+	api := api_gateway.NewConnectionQueryApi(repo)
 
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i)
@@ -46,7 +46,7 @@ func TestConnectionQueryApi_GetAllConnectionList(t *testing.T) {
 
 func TestConnectionQueryApi_GetConnectionByID(t *testing.T) {
 	repo := api_gateway.NewConnectionRepository()
-	api := api_gateway.NewConnectionQueryApi(*repo)
+	api := api_gateway.NewConnectionQueryApi(repo)
 	ids := [4]string{"it-chain", "engine", "api_gateway", "makehoney"}
 
 	for i := 0; i < len(ids); i++ {
@@ -133,7 +133,7 @@ func TestConnectionRepository_Remove(t *testing.T) {
 
 func TestConnectionEventListener_HandleConnectionCreatedEvent(t *testing.T) {
 	repo := api_gateway.NewConnectionRepository()
-	listener := api_gateway.NewConnectionEventListener(*repo)
+	listener := api_gateway.NewConnectionEventListener(repo)
 
 	err := listener.HandleConnectionCreatedEvent(event.ConnectionCreated{
 		ConnectionID: "0",
@@ -144,7 +144,7 @@ func TestConnectionEventListener_HandleConnectionCreatedEvent(t *testing.T) {
 
 func TestConnectionEventListener_HandleConnectionClosedEvent(t *testing.T) {
 	repo := api_gateway.NewConnectionRepository()
-	listener := api_gateway.NewConnectionEventListener(*repo)
+	listener := api_gateway.NewConnectionEventListener(repo)
 
 	err := listener.HandleConnectionCreatedEvent(event.ConnectionCreated{
 		ConnectionID: "0",

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -27,29 +27,38 @@ type Endpoints struct {
 	FindAllCommittedBlocksEndpoint   endpoint.Endpoint
 	FindCommittedBlockBySealEndpoint endpoint.Endpoint
 	FindAllMetaEndpoint              endpoint.Endpoint
+	FindAllConnectionEndpoint        endpoint.Endpoint
+	FindConnectionByIdEndpoint       endpoint.Endpoint
 }
 
 /*
  * returns endpoints
  */
 
-func MakeBlockchainEndpoints(b BlockQueryApi) Endpoints {
+func MakeBlockchainEndpoints(b *BlockQueryApi) Endpoints {
 	return Endpoints{
 		FindAllCommittedBlocksEndpoint:   makeFindAllCommittedBlocksEndpoint(b),
 		FindCommittedBlockBySealEndpoint: makeFindCommittedBlockBySealEndpoint(b),
 	}
 }
 
-func MakeIvmEndpoints(i ICodeQueryApi) Endpoints {
+func MakeIvmEndpoints(i *ICodeQueryApi) Endpoints {
 	return Endpoints{
 		FindAllMetaEndpoint: makeFindAllMetaEndpoint(i),
+	}
+}
+
+func MakeConnectionEndpoints(c *ConnectionQueryApi) Endpoints {
+	return Endpoints{
+		FindAllConnectionEndpoint:  makeFindAllConnectionEndpoint(c),
+		FindConnectionByIdEndpoint: makeFindConnectionByIdEndpoint(c),
 	}
 }
 
 /*
  * blockchain
  */
-func makeFindAllCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
+func makeFindAllCommittedBlocksEndpoint(b *BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		if request == nil {
 			blocks, err := b.blockRepository.FindAllBlock()
@@ -69,7 +78,7 @@ func makeFindAllCommittedBlocksEndpoint(b BlockQueryApi) endpoint.Endpoint {
 	}
 }
 
-func makeFindCommittedBlockBySealEndpoint(b BlockQueryApi) endpoint.Endpoint {
+func makeFindCommittedBlockBySealEndpoint(b *BlockQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(FindCommittedBlockBySealRequest)
 		block, err := b.blockRepository.FindBlockBySeal(req.Seal)
@@ -81,7 +90,7 @@ func makeFindCommittedBlockBySealEndpoint(b BlockQueryApi) endpoint.Endpoint {
 }
 
 //ivm
-func makeFindAllMetaEndpoint(i ICodeQueryApi) endpoint.Endpoint {
+func makeFindAllMetaEndpoint(i *ICodeQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		metas, err := i.iCodeRepository.FindAllMeta()
 		if err != nil {
@@ -98,4 +107,31 @@ type FindCommittedBlockByHeightRequest struct {
 
 type FindCommittedBlockBySealRequest struct {
 	Seal []byte
+}
+
+func makeFindAllConnectionEndpoint(c *ConnectionQueryApi) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		connections, err := c.GetAllConnectionList()
+		if err != nil {
+			logger.Error(nil, "[Api-gateway] Error while finding all connections")
+			return nil, err
+		}
+		return connections, nil
+	}
+}
+
+func makeFindConnectionByIdEndpoint(c *ConnectionQueryApi) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(FindConnectionByIdRequest)
+		connections, err := c.GetConnectionByID(req.ConnectionId)
+		if err != nil {
+			logger.Error(nil, "[Api-gateway] Error while finding all connections")
+			return nil, err
+		}
+		return connections, nil
+	}
+}
+
+type FindConnectionByIdRequest struct {
+	ConnectionId string
 }

--- a/api_gateway/icode_query_api.go
+++ b/api_gateway/icode_query_api.go
@@ -30,8 +30,8 @@ type ICodeQueryApi struct {
 	iCodeRepository ICodeRepository
 }
 
-func NewICodeQueryApi(repository ICodeRepository) ICodeQueryApi {
-	return ICodeQueryApi{
+func NewICodeQueryApi(repository ICodeRepository) *ICodeQueryApi {
+	return &ICodeQueryApi{
 		iCodeRepository: repository,
 	}
 }


### PR DESCRIPTION
resolved: #852

details:
Add endpoints of connection query api


Now we can query connection list on localhost:4000/connections or localhost:4000/connections/{id}
