### PR TITLE
Implement txpool's engine mode dividing

### DIFF
--- a/cmd/on/txpoolfx/txpoolfx.go
+++ b/cmd/on/txpoolfx/txpoolfx.go
@@ -21,12 +21,14 @@ import (
 
 	"context"
 
+	"github.com/it-chain/engine/common/batch"
+	"github.com/it-chain/engine/common/command"
 	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
+	"github.com/it-chain/engine/txpool"
 	"github.com/it-chain/engine/txpool/api"
 	"github.com/it-chain/engine/txpool/infra/adapter"
-	"github.com/it-chain/engine/txpool/infra/batch"
 	"github.com/it-chain/engine/txpool/infra/mem"
 	"go.uber.org/fx"
 )
@@ -46,8 +48,8 @@ var Module = fx.Options(
 	),
 )
 
-func NewBlockProposalService(repository *mem.TransactionRepository, client *rpc.Client, config *conf.Configuration) *adapter.BlockProposalService {
-	return adapter.NewBlockProposalService(client, repository, config.Engine.Mode)
+func NewBlockProposalService(repository *mem.TransactionRepository, client *rpc.Client, config *conf.Configuration, peerQueryService txpool.PeerQueryService, peer command.MyPeer) *adapter.BlockProposalService {
+	return adapter.NewBlockProposalService(client, repository, config.Engine.Mode, peerQueryService, peer)
 }
 
 func NewTxpoolApi(repository *mem.TransactionRepository) *api.TransactionApi {

--- a/common/batch/timeout_batcher.go
+++ b/common/batch/timeout_batcher.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 It-chain
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package batch
+
+import (
+	"time"
+
+	"sync"
+
+	"github.com/it-chain/engine/common/logger"
+)
+
+var instance *TimeoutBatcher
+var once sync.Once
+
+type TaskFunc func() error
+
+func GetTimeOutBatcherInstance() *TimeoutBatcher {
+
+	once.Do(func() {
+		instance = newTimeoutBatcher()
+	})
+
+	return instance
+}
+
+type Task struct {
+	T        *time.Ticker
+	quit     chan struct{}
+	taskFunc func() error
+}
+
+func NewTimer(duration time.Duration, taskFunc func() error) Task {
+	return Task{
+		quit:     make(chan struct{}, 1),
+		T:        time.NewTicker(duration),
+		taskFunc: taskFunc,
+	}
+}
+
+func (t *Task) Start() error {
+
+	for {
+		select {
+		case <-t.T.C:
+			if err := t.taskFunc(); err != nil {
+				logger.Error(nil, "error: "+err.Error())
+			}
+		case <-t.quit:
+			t.Stop()
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) Stop() {
+	t.T.Stop()
+}
+
+type TimeoutBatcher struct {
+	timers map[string]Task
+}
+
+func newTimeoutBatcher() *TimeoutBatcher {
+
+	return &TimeoutBatcher{
+		timers: make(map[string]Task),
+	}
+}
+
+func (t *TimeoutBatcher) Run(taskFunc TaskFunc, duration time.Duration) chan struct{} {
+
+	timer := NewTimer(duration, taskFunc)
+
+	var err error
+
+	go func() {
+		//defer log.Println("timer is closing")
+		err = timer.Start()
+
+		if err != nil {
+			logger.Error(nil, "error: "+err.Error())
+			//	return
+		}
+	}()
+
+	return timer.quit
+}

--- a/common/batch/timeout_batcher_test.go
+++ b/common/batch/timeout_batcher_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 It-chain
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package batch
+
+import (
+	"testing"
+	"time"
+
+	"sync"
+
+	"fmt"
+)
+
+//todo return error 했을 경우 test할 방법이 없음
+func TestTimeoutBatcher_Run(t *testing.T) {
+
+	wg := sync.WaitGroup{}
+
+	counter := 0
+	//given
+	tests := map[string]struct {
+		input struct {
+			taskFunc TaskFunc
+			duration time.Duration
+		}
+		err error
+	}{
+		"success": {
+			input: struct {
+				taskFunc TaskFunc
+				duration time.Duration
+			}{
+				taskFunc: func() error {
+					if counter == 0 {
+						wg.Done()
+						fmt.Println("success done")
+					}
+
+					counter++
+
+					return nil
+				},
+				duration: time.Second * 3,
+			},
+			err: nil,
+		},
+	}
+
+	batcher := GetTimeOutBatcherInstance()
+	wg.Add(1)
+
+	for testName, test := range tests {
+		t.Logf("Running test case %s", testName)
+
+		//when
+		counter = 0
+		quit := batcher.Run(test.input.taskFunc, test.input.duration)
+		wg.Wait()
+		quit <- struct{}{}
+	}
+}

--- a/common/command/command.go
+++ b/common/command/command.go
@@ -71,6 +71,11 @@ type ReceiveGrpc struct {
 	Protocol     string
 }
 
+type MyPeer struct {
+	IpAddress string
+	PeerId    string
+}
+
 /*
  * ivm
  */

--- a/txpool/peer.go
+++ b/txpool/peer.go
@@ -16,29 +16,13 @@
 
 package txpool
 
-type TxpoolQueryService interface {
-	FindUncommittedTransactions() ([]Transaction, error)
+// 노드 구조체 선언.
+type Peer struct {
+	IpAddress string
+	PeerId    PeerId
 }
 
-type PeerQueryService interface {
-	GetPeerList() ([]Peer, error)
-	GetLeader() (Leader, error)
-}
-
-type TransferService interface {
-	SendTransactionsToLeader(transactions []Transaction, leader Leader) error
-}
-
-type BlockProposalService interface {
-	ProposeBlock() error
-}
-
-func filter(vs []Transaction, f func(Transaction) bool) []Transaction {
-	vsf := make([]Transaction, 0)
-	for _, v := range vs {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
+// PeerId 선언
+type PeerId struct {
+	Id string
 }

--- a/txpool/test/mock/mock_service.go
+++ b/txpool/test/mock/mock_service.go
@@ -14,31 +14,21 @@
  * limitations under the License.
  */
 
-package txpool
+package mock
 
-type TxpoolQueryService interface {
-	FindUncommittedTransactions() ([]Transaction, error)
+import (
+	"github.com/it-chain/engine/p2p"
+)
+
+type PeerQueryService struct {
+	GetPeerListFunc func() ([]p2p.Peer, error)
+	GetLeaderFunc   func() (p2p.Leader, error)
 }
 
-type PeerQueryService interface {
-	GetPeerList() ([]Peer, error)
-	GetLeader() (Leader, error)
+func (m PeerQueryService) GetPeerList() ([]p2p.Peer, error) {
+	return m.GetPeerListFunc()
 }
 
-type TransferService interface {
-	SendTransactionsToLeader(transactions []Transaction, leader Leader) error
-}
-
-type BlockProposalService interface {
-	ProposeBlock() error
-}
-
-func filter(vs []Transaction, f func(Transaction) bool) []Transaction {
-	vsf := make([]Transaction, 0)
-	for _, v := range vs {
-		if f(v) {
-			vsf = append(vsf, v)
-		}
-	}
-	return vsf
+func (m PeerQueryService) GetLeader() (p2p.Leader, error) {
+	return m.GetLeaderFunc()
 }


### PR DESCRIPTION
resolved: txpool engine mode dividing #838 

details:

1. In block_propose_service.go, make a pbft mode (when i'm leader, propose the block)
2. In transfer_service.go, make a pbft mode (when i'm not leader, send transactions to leader)
3. In txpool, make test/mock/mock_service.go to test 1 and 2 above.
4. move txpool/infra/batch folder to common folder

 - [x] Test case
