### PR TITLE
[common] modify using log from common/logger package to iLogger library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,6 +231,14 @@
   version = "v0.1.3"
 
 [[projects]]
+  branch = "master"
+  digest = "1:fc8c6e572c48333301455a5219851b5bf5dd831bf0397b4edfe0c0f34d1a6001"
+  name = "github.com/it-chain/iLogger"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3d4855e59818211a0ec2df9b0e9a242472f5878d"
+
+[[projects]]
   digest = "1:cde7960c5ad197abbf88392e615ce21f54fe884b815ca186efe43a367263fa1e"
   name = "github.com/it-chain/leveldb-wrapper"
   packages = [
@@ -806,6 +814,7 @@
     "github.com/it-chain/bifrost/pb",
     "github.com/it-chain/bifrost/server",
     "github.com/it-chain/heimdall/key",
+    "github.com/it-chain/iLogger",
     "github.com/it-chain/leveldb-wrapper",
     "github.com/it-chain/midgard",
     "github.com/it-chain/sdk",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -113,3 +113,7 @@ ignored = ["github.com/mock/handler"]
 [[constraint]]
   name = "go.uber.org/fx"
   version = "1.7.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/it-chain/iLogger"

--- a/api_gateway/endpoint.go
+++ b/api_gateway/endpoint.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/go-kit/kit/endpoint"
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 )
 
 type Endpoints struct {
@@ -93,7 +93,7 @@ func makeFindAllMetaEndpoint(i *ICodeQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		metas, err := i.iCodeRepository.FindAllMeta()
 		if err != nil {
-			logger.Error(&logger.Fields{"err_message": err.Error()}, "error while find all meta endpoint")
+			iLogger.Error(&iLogger.Fields{"err_message": err.Error()}, "error while find all meta endpoint")
 			return nil, err
 		}
 
@@ -116,7 +116,7 @@ func makeFindAllConnectionEndpoint(c *ConnectionQueryApi) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		connections, err := c.GetAllConnectionList()
 		if err != nil {
-			logger.Error(nil, "[Api-gateway] Error while finding all connections")
+			iLogger.Error(nil, "[Api-gateway] Error while finding all connections")
 			return nil, err
 		}
 		return connections, nil
@@ -128,7 +128,7 @@ func makeFindConnectionByIdEndpoint(c *ConnectionQueryApi) endpoint.Endpoint {
 		req := request.(FindConnectionByIdRequest)
 		connections, err := c.GetConnectionByID(req.ConnectionId)
 		if err != nil {
-			logger.Error(nil, "[Api-gateway] Error while finding all connections")
+			iLogger.Error(nil, "[Api-gateway] Error while finding all connections")
 			return nil, err
 		}
 		return connections, nil

--- a/blockchain/api/block_api.go
+++ b/blockchain/api/block_api.go
@@ -22,7 +22,7 @@ import (
 	"github.com/it-chain/engine/blockchain"
 	"github.com/it-chain/engine/blockchain/infra/mem"
 	"github.com/it-chain/engine/common/event"
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 )
 
 type BlockApi struct {
@@ -70,14 +70,14 @@ func (api BlockApi) ConsentBlock(consensusType string, block blockchain.DefaultB
 		return api.eventService.Publish("block.consent", event)
 
 	default:
-		logger.Error(nil, fmt.Sprintf("[blockchain] undefined consensus type: %v", consensusType))
+		iLogger.Error(nil, fmt.Sprintf("[blockchain] undefined consensus type: %v", consensusType))
 		return ErrUndefinedConsensusType
 	}
 
 }
 
 func (bApi BlockApi) CommitGenesisBlock(GenesisConfPath string) error {
-	logger.Info(nil, "[Blockchain] Committing genesis block")
+	iLogger.Info(nil, "[Blockchain] Committing genesis block")
 
 	// create
 	GenesisBlock, err := blockchain.CreateGenesisBlock(GenesisConfPath)
@@ -102,7 +102,7 @@ func (bApi BlockApi) CommitGenesisBlock(GenesisConfPath string) error {
 		return ErrCreateEvent
 	}
 
-	logger.Info(nil, fmt.Sprintf("[Blockchain] Genesis block has Committed - seal: [%x], height: [%d]", GenesisBlock.Seal, GenesisBlock.Height))
+	iLogger.Info(nil, fmt.Sprintf("[Blockchain] Genesis block has Committed - seal: [%x], height: [%d]", GenesisBlock.Seal, GenesisBlock.Height))
 
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }
@@ -112,7 +112,7 @@ set state to 'committed'
 publish block committed event
 */
 func (bApi BlockApi) CommitBlock(block blockchain.DefaultBlock) error {
-	logger.Info(nil, "[Blockchain] Committing proposed block")
+	iLogger.Info(nil, "[Blockchain] Committing proposed block")
 
 	// save(commit)
 	block.SetState(blockchain.Committed)
@@ -130,7 +130,7 @@ func (bApi BlockApi) CommitBlock(block blockchain.DefaultBlock) error {
 		return ErrCreateEvent
 	}
 
-	logger.Info(nil, fmt.Sprintf("[Blockchain] Proposed block has Committed - seal: [%x],  height: [%d]", block.Seal, block.Height))
+	iLogger.Info(nil, fmt.Sprintf("[Blockchain] Proposed block has Committed - seal: [%x],  height: [%d]", block.Seal, block.Height))
 
 	return bApi.eventService.Publish("block.committed", commitEvent)
 }
@@ -143,7 +143,7 @@ func (bApi BlockApi) StageBlock(block blockchain.DefaultBlock) error {
 }
 
 func (api BlockApi) CreateProposedBlock(txList []*blockchain.DefaultTransaction) (blockchain.DefaultBlock, error) {
-	logger.Info(nil, "[Blockchain] Create proposed block")
+	iLogger.Info(nil, "[Blockchain] Create proposed block")
 	lastBlock, err := api.blockRepository.FindLast()
 	if err != nil {
 		return blockchain.DefaultBlock{}, ErrGetLastBlock

--- a/blockchain/api/sync_api.go
+++ b/blockchain/api/sync_api.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"github.com/it-chain/engine/blockchain"
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 )
 
 type SyncApi struct {
@@ -41,25 +41,25 @@ func (sApi SyncApi) Synchronize() error {
 	// get random peer
 	randomPeer, err := sApi.queryService.GetRandomPeer()
 
-	logger.Infof(nil, "[Blockchain] Start to Synchronize - PeerID: [%s]", randomPeer.PeerID)
+	iLogger.Infof(nil, "[Blockchain] Start to Synchronize - PeerID: [%s]", randomPeer.PeerID)
 	if err != nil {
-		logger.Errorf(nil, "[Blockchain] Fail to Synchronize - Err: [%s]", err)
+		iLogger.Errorf(nil, "[Blockchain] Fail to Synchronize - Err: [%s]", err)
 		return err
 	}
 
 	if sApi.isSynced(randomPeer) {
-		logger.Infof(nil, "[Blockchain] Already Synchronized - PeerID: [%s]", randomPeer.PeerID)
+		iLogger.Infof(nil, "[Blockchain] Already Synchronized - PeerID: [%s]", randomPeer.PeerID)
 		return nil
 	}
 
 	// if sync has not done, on sync
 	err = sApi.syncWithPeer(randomPeer)
 	if err != nil {
-		logger.Errorf(nil, "[Blockchain] Fail to Synchronize - Err: [%s]", err)
+		iLogger.Errorf(nil, "[Blockchain] Fail to Synchronize - Err: [%s]", err)
 		return err
 	}
 
-	logger.Infof(nil, "[Blockchain] Synchronized Successfully - PeerID: [%s]", randomPeer.PeerID)
+	iLogger.Infof(nil, "[Blockchain] Synchronized Successfully - PeerID: [%s]", randomPeer.PeerID)
 
 	return nil
 
@@ -143,7 +143,7 @@ func (sApi SyncApi) commitBlock(block blockchain.DefaultBlock) error {
 	// save(commit)
 	err := sApi.blockRepository.Save(block)
 	if err != nil {
-		logger.Errorf(nil, "[Blockchain] Block is not Committed - Err: [%s]", err)
+		iLogger.Errorf(nil, "[Blockchain] Block is not Committed - Err: [%s]", err)
 		return ErrSaveBlock
 	}
 
@@ -153,7 +153,7 @@ func (sApi SyncApi) commitBlock(block blockchain.DefaultBlock) error {
 		return ErrCreateEvent
 	}
 
-	logger.Infof(nil, "[Blockchain] Block has Committed - seal: [%x],  height: [%d]", block.Seal, block.Height)
+	iLogger.Infof(nil, "[Blockchain] Block has Committed - seal: [%x],  height: [%d]", block.Seal, block.Height)
 
 	return sApi.eventService.Publish("block.committed", commitEvent)
 }

--- a/cmd/connection/dial.go
+++ b/cmd/connection/dial.go
@@ -18,10 +18,10 @@ package connection
 
 import (
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/grpc_gateway"
+	"github.com/it-chain/iLogger"
 	"github.com/urfave/cli"
 )
 
@@ -46,19 +46,19 @@ func dial(ip string) error {
 		Address: ip,
 	}
 
-	logger.Infof(nil, "[Cmd] Creating connection - Address: [%s]", ip)
+	iLogger.Infof(nil, "[Cmd] Creating connection - Address: [%s]", ip)
 	err := client.Call("connection.create", createConnectionCommand, func(connection grpc_gateway.Connection, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Fatalf(nil, "[Cmd] Fail to create connection - Address: [%s]", ip)
+			iLogger.Fatalf(nil, "[Cmd] Fail to create connection - Address: [%s]", ip)
 			return
 		}
 
-		logger.Infof(nil, "[Cmd] Connection created - gRPC-Address: [%s], Id:[%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
+		iLogger.Infof(nil, "[Cmd] Connection created - gRPC-Address: [%s], Id:[%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
 	})
 
 	if err != nil {
-		logger.Fatal(nil, err.Error())
+		iLogger.Fatal(nil, err.Error())
 	}
 
 	return nil

--- a/cmd/connection/join.go
+++ b/cmd/connection/join.go
@@ -18,9 +18,9 @@ package connection
 
 import (
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
+	"github.com/it-chain/iLogger"
 	"github.com/urfave/cli"
 )
 
@@ -45,19 +45,19 @@ func join(ip string) error {
 		Address: ip,
 	}
 
-	logger.Infof(nil, "[Cmd] Joining network - Address: [%s]", ip)
+	iLogger.Infof(nil, "[Cmd] Joining network - Address: [%s]", ip)
 	err := client.Call("connection.join", joinNetworkCommand, func(_ struct{}, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Fatalf(nil, "[Cmd] Fail to join network - Address: [%s], Err: [%s]", ip, err.Message)
+			iLogger.Fatalf(nil, "[Cmd] Fail to join network - Address: [%s], Err: [%s]", ip, err.Message)
 			return
 		}
 
-		logger.Info(nil, "[Cmd] Successfully request to join network")
+		iLogger.Info(nil, "[Cmd] Successfully request to join network")
 	})
 
 	if err != nil {
-		logger.Fatal(nil, err.Error())
+		iLogger.Fatal(nil, err.Error())
 	}
 
 	return nil

--- a/cmd/connection/list.go
+++ b/cmd/connection/list.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
+	"github.com/it-chain/iLogger"
 	"github.com/urfave/cli"
 )
 
@@ -46,7 +46,7 @@ func list() error {
 	err := client.Call("connection.list", getConnectionList, func(getConnectionListCommand command.GetConnectionList, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Fatalf(nil, "[Cmd] Fail to get connection list")
+			iLogger.Fatalf(nil, "[Cmd] Fail to get connection list")
 			return
 		}
 
@@ -58,7 +58,7 @@ func list() error {
 	})
 
 	if err != nil {
-		logger.Fatal(nil, err.Error())
+		iLogger.Fatal(nil, err.Error())
 	}
 
 	return nil

--- a/cmd/ivm/deploy.go
+++ b/cmd/ivm/deploy.go
@@ -22,10 +22,10 @@ import (
 	"github.com/it-chain/engine/common"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/ivm"
+	"github.com/it-chain/iLogger"
 	"github.com/rs/xid"
 	"github.com/urfave/cli"
 )
@@ -65,17 +65,17 @@ func deploy(gitUrl string, sshPath string, password string) {
 		Password: password,
 	}
 
-	logger.Infof(nil, "[Cmd] deploying icode...")
-	logger.Infof(nil, "[Cmd] This may take a few minutes")
+	iLogger.Infof(nil, "[Cmd] deploying icode...")
+	iLogger.Infof(nil, "[Cmd] This may take a few minutes")
 
 	err = client.Call("ivm.deploy", deployCommand, func(icode ivm.ICode, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Infof(nil, "fail to deploy icode err: [%s]", err.Message)
+			iLogger.Infof(nil, "fail to deploy icode err: [%s]", err.Message)
 			return
 		}
 
-		logger.Infof(nil, "[Cmd] icode has deployed - icodeID: [%s]", icode.ID)
+		iLogger.Infof(nil, "[Cmd] icode has deployed - icodeID: [%s]", icode.ID)
 	})
 
 	if err != nil {

--- a/cmd/ivm/invoke.go
+++ b/cmd/ivm/invoke.go
@@ -20,10 +20,10 @@ import (
 	"errors"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/txpool"
+	"github.com/it-chain/iLogger"
 	"github.com/rs/xid"
 	"github.com/urfave/cli"
 )
@@ -68,19 +68,19 @@ func invoke(id string, functionName string, args []string) {
 		Function:      functionName,
 	}
 
-	logger.Infof(nil, "[Cmd] Invoke icode - icodeID: [%s]", id)
+	iLogger.Infof(nil, "[Cmd] Invoke icode - icodeID: [%s]", id)
 
 	err := client.Call("transaction.create", invokeCommand, func(transaction txpool.Transaction, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Errorf(nil, "[Cmd] Fail to invoke icode err: [%s]", err.Message)
+			iLogger.Errorf(nil, "[Cmd] Fail to invoke icode err: [%s]", err.Message)
 			return
 		}
 
-		logger.Infof(nil, "[Cmd] Transactions are created - ID: [%s]", transaction.ID)
+		iLogger.Infof(nil, "[Cmd] Transactions are created - ID: [%s]", transaction.ID)
 	})
 
 	if err != nil {
-		logger.Fatal(&logger.Fields{"err_msg": err.Error()}, "fatal err in query cmd")
+		iLogger.Fatal(&iLogger.Fields{"err_msg": err.Error()}, "fatal err in query cmd")
 	}
 }

--- a/cmd/ivm/query.go
+++ b/cmd/ivm/query.go
@@ -20,10 +20,10 @@ import (
 	"errors"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/ivm"
+	"github.com/it-chain/iLogger"
 	"github.com/urfave/cli"
 )
 
@@ -62,20 +62,20 @@ func query(id string, functionName string, args []string) {
 		Method:   "query",
 	}
 
-	logger.Infof(nil, "[Cmd] Querying icode - icodeID: [%s], func: [%s]", id, functionName)
+	iLogger.Infof(nil, "[Cmd] Querying icode - icodeID: [%s], func: [%s]", id, functionName)
 
 	err := client.Call("ivm.execute", queryCommand, func(result ivm.Result, err rpc.Error) {
 		if !err.IsNil() {
-			logger.Errorf(nil, "[Cmd] Fail to query icode err: [%s]", err.Message)
+			iLogger.Errorf(nil, "[Cmd] Fail to query icode err: [%s]", err.Message)
 			return
 		}
 
 		for key, val := range result.Data {
-			logger.Infof(nil, "[CMD] Querying result - key: [%s], value: [%s]", key, val)
+			iLogger.Infof(nil, "[CMD] Querying result - key: [%s], value: [%s]", key, val)
 		}
 	})
 
 	if err != nil {
-		logger.Fatal(&logger.Fields{"err_msg": err.Error()}, "fatal err in query cmd")
+		iLogger.Fatal(&iLogger.Fields{"err_msg": err.Error()}, "fatal err in query cmd")
 	}
 }

--- a/cmd/on/api-gatewayfx/api_gatewayfx.go
+++ b/cmd/on/api-gatewayfx/api_gatewayfx.go
@@ -21,10 +21,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/it-chain/iLogger"
+
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/it-chain/engine/api_gateway"
 	"github.com/it-chain/engine/common"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/pubsub"
 	"github.com/it-chain/engine/conf"
 	"go.uber.org/fx"
@@ -116,7 +117,7 @@ func InitApiGatewayServer(lifecycle fx.Lifecycle, config *conf.Configuration, ha
 
 	lifecycle.Append(fx.Hook{
 		OnStart: func(context context.Context) error {
-			logger.Infof(nil, "[Main] Api-gateway is staring on port:%s", config.ApiGateway.Port)
+			iLogger.Infof(nil, "[Main] Api-gateway is staring on port:%s", config.ApiGateway.Port)
 			go func() {
 				err := http.ListenAndServe(ipAddress, handler)
 				if err != nil {

--- a/cmd/on/blockchainfx/blockchainfx.go
+++ b/cmd/on/blockchainfx/blockchainfx.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"os"
 
+	"github.com/it-chain/iLogger"
+
 	"github.com/it-chain/engine/blockchain/api"
 	"github.com/it-chain/engine/blockchain/infra/adapter"
 	"github.com/it-chain/engine/blockchain/infra/mem"
@@ -27,7 +29,6 @@ import (
 
 	"github.com/it-chain/engine/api_gateway"
 	"github.com/it-chain/engine/common"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/pubsub"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
@@ -94,7 +95,7 @@ func CreateGenesisBlock(blockApi *api.BlockApi, config *conf.Configuration) {
 }
 
 func RegisterRpcHandlers(server *rpc.Server, handler *adapter.BlockProposeCommandHandler) {
-	logger.Infof(nil, "[Main] Blockchain is starting")
+	iLogger.Infof(nil, "[Main] Blockchain is starting")
 	if err := server.Register("block.propose", handler.HandleProposeBlockCommand); err != nil {
 		panic(err)
 	}

--- a/cmd/on/grpc_gatewayfx/grpc_gatewayfx.go
+++ b/cmd/on/grpc_gatewayfx/grpc_gatewayfx.go
@@ -20,13 +20,13 @@ import (
 	"context"
 
 	"github.com/it-chain/engine/common"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/pubsub"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/grpc_gateway/api"
 	"github.com/it-chain/engine/grpc_gateway/infra"
 	"github.com/it-chain/engine/grpc_gateway/infra/adapter"
+	"github.com/it-chain/iLogger"
 	"go.uber.org/fx"
 )
 
@@ -64,7 +64,7 @@ func NewConnectionApi(hostService *infra.GrpcHostService, eventService common.Ev
 }
 
 func RegisterHandlers(connectionCommandHandler *adapter.ConnectionCommandHandler, server *rpc.Server) {
-	logger.Infof(nil, "[Main] gRPC-Gateway is starting")
+	iLogger.Infof(nil, "[Main] gRPC-Gateway is starting")
 	if err := server.Register("connection.create", connectionCommandHandler.HandleCreateConnectionCommand); err != nil {
 		panic(err)
 	}

--- a/cmd/on/init.go
+++ b/cmd/on/init.go
@@ -26,7 +26,7 @@ import (
 	"github.com/it-chain/engine/cmd/on/grpc_gatewayfx"
 	"github.com/it-chain/engine/cmd/on/ivmfx"
 	"github.com/it-chain/engine/cmd/on/txpoolfx"
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 	"github.com/urfave/cli"
 	"go.uber.org/fx"
 )
@@ -51,12 +51,12 @@ func Action(c *cli.Context) error {
 
 func clearFolder() {
 	if err := os.RemoveAll(api_gatewayfx.ApidbPath); err != nil {
-		logger.Panic(&logger.Fields{"err_msg": err.Error()}, "error while clear folder")
+		iLogger.Panic(&iLogger.Fields{"err_msg": err.Error()}, "error while clear folder")
 		panic(err)
 	}
 
 	if err := os.RemoveAll(blockchainfx.BbPath); err != nil {
-		logger.Panic(&logger.Fields{"err_msg": err.Error()}, "error while clear folder")
+		iLogger.Panic(&iLogger.Fields{"err_msg": err.Error()}, "error while clear folder")
 		panic(err)
 	}
 }

--- a/cmd/on/ivmfx/ivmfx.go
+++ b/cmd/on/ivmfx/ivmfx.go
@@ -19,7 +19,8 @@ package ivmfx
 import (
 	"context"
 
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
+
 	"github.com/it-chain/engine/common/rabbitmq/pubsub"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/ivm"
@@ -79,7 +80,7 @@ func RegisterRpcHandlers(
 }
 
 func RegisterPubsubHandlers(subscriber *pubsub.TopicSubscriber, handler *adapter.BlockCommittedEventHandler) {
-	logger.Infof(nil, "[Main] Ivm is starting")
+	iLogger.Infof(nil, "[Main] Ivm is starting")
 	if err := subscriber.SubscribeTopic("block.*", handler); err != nil {
 		panic(err)
 	}

--- a/cmd/on/txpoolfx/txpoolfx.go
+++ b/cmd/on/txpoolfx/txpoolfx.go
@@ -19,9 +19,10 @@ package txpoolfx
 import (
 	"time"
 
+	"github.com/it-chain/iLogger"
+
 	"context"
 
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/conf"
 	"github.com/it-chain/engine/txpool/api"
@@ -70,7 +71,7 @@ func RunBatcher(lifecycle fx.Lifecycle, blockProposalService *adapter.BlockPropo
 }
 
 func RegisterRpcHandlers(server *rpc.Server, handler *adapter.TxCommandHandler) {
-	logger.Infof(nil, "[Main] Txpool is starting")
+	iLogger.Infof(nil, "[Main] Txpool is starting")
 	if err := server.Register("transaction.create", handler.HandleTxCreateCommand); err != nil {
 		panic(err)
 	}

--- a/grpc_gateway/api/connection_api.go
+++ b/grpc_gateway/api/connection_api.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/event"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/grpc_gateway"
+	"github.com/it-chain/iLogger"
 )
 
 type ConnectionApi struct {
@@ -41,11 +41,11 @@ func NewConnectionApi(grpcService grpc_gateway.GrpcService, eventService common.
 
 // create all connections
 func (c ConnectionApi) JoinNetwork(address string) error {
-	logger.Infof(nil, "[gRPC-Gateway] Joining it-chain network - Address: [%s]", address)
+	iLogger.Infof(nil, "[gRPC-Gateway] Joining it-chain network - Address: [%s]", address)
 
 	connection, err := c.Dial(address)
 	if err != nil {
-		logger.Errorf(nil, "[gRPC-Gateway] Fail to join - Err: [%s]", err)
+		iLogger.Errorf(nil, "[gRPC-Gateway] Fail to join - Err: [%s]", err)
 		return err
 	}
 
@@ -57,11 +57,11 @@ func (c ConnectionApi) JoinNetwork(address string) error {
 // create connection only for the address
 func (c ConnectionApi) Dial(address string) (grpc_gateway.Connection, error) {
 
-	logger.Infof(nil, "[gRPC-Gateway] Dialing - Address: [%s]", address)
+	iLogger.Infof(nil, "[gRPC-Gateway] Dialing - Address: [%s]", address)
 
 	connection, err := c.grpcService.Dial(address)
 	if err != nil {
-		logger.Errorf(nil, "[gRPC-Gateway] Fail to dial - Err: [%s]", err)
+		iLogger.Errorf(nil, "[gRPC-Gateway] Fail to dial - Err: [%s]", err)
 		return grpc_gateway.Connection{}, err
 	}
 
@@ -70,7 +70,7 @@ func (c ConnectionApi) Dial(address string) (grpc_gateway.Connection, error) {
 		return connection, err
 	}
 
-	logger.Infof(nil, "[gRPC-Gateway] Connection created - gRPC-Address [%s], ConnectionID [%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
+	iLogger.Infof(nil, "[gRPC-Gateway] Connection created - gRPC-Address [%s], ConnectionID [%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
 
 	return connection, nil
 }
@@ -84,7 +84,7 @@ func createConnectionCreatedEvent(connection grpc_gateway.Connection) event.Conn
 }
 
 func (c ConnectionApi) CloseConnection(connectionID string) error {
-	logger.Infof(nil, "[gRPC-Gateway] Close connection - ConnectionID [%s]", connectionID)
+	iLogger.Infof(nil, "[gRPC-Gateway] Close connection - ConnectionID [%s]", connectionID)
 
 	c.grpcService.CloseConnection(connectionID)
 
@@ -98,18 +98,18 @@ func createConnectionClosedEvent(connectionID string) event.ConnectionClosed {
 }
 
 func (c ConnectionApi) OnConnection(connection grpc_gateway.Connection) {
-	logger.Infof(nil, "[gRPC-Gateway] Connection created - gRPC-Address [%s], ConnectionID [%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
+	iLogger.Infof(nil, "[gRPC-Gateway] Connection created - gRPC-Address [%s], ConnectionID [%s]", connection.GrpcGatewayAddress, connection.ConnectionID)
 
 	if err := c.eventService.Publish("connection.created", createConnectionCreatedEvent(connection)); err != nil {
-		logger.Infof(nil, "[gRPC-Gateway] Fail to publish connection createdEvent - ConnectionID: [%s]", connection.ConnectionID)
+		iLogger.Infof(nil, "[gRPC-Gateway] Fail to publish connection createdEvent - ConnectionID: [%s]", connection.ConnectionID)
 	}
 }
 
 func (c ConnectionApi) OnDisconnection(connection grpc_gateway.Connection) {
-	logger.Infof(nil, "[gRPC-Gateway] Connection closed - ConnectionID [%s]", connection.ConnectionID)
+	iLogger.Infof(nil, "[gRPC-Gateway] Connection closed - ConnectionID [%s]", connection.ConnectionID)
 
 	if err := c.eventService.Publish("connection.closed", createConnectionClosedEvent(connection.ConnectionID)); err != nil {
-		logger.Infof(nil, "[gRPC-Gateway] Fail to publish connection createdEvent - ConnectionID: [%s]", connection.ConnectionID)
+		iLogger.Infof(nil, "[gRPC-Gateway] Fail to publish connection createdEvent - ConnectionID: [%s]", connection.ConnectionID)
 	}
 }
 
@@ -122,7 +122,7 @@ func (c ConnectionApi) HandleRequestPeerList(connectionId string) {
 	connectionList, _ := c.grpcService.GetAllConnections()
 	response, err := json.Marshal(connectionList)
 	if err != nil {
-		logger.Errorf(nil, "[gRPC-Gateway] Fail to handle request peer list - Err: [%s]", err.Error())
+		iLogger.Errorf(nil, "[gRPC-Gateway] Fail to handle request peer list - Err: [%s]", err.Error())
 		return
 	}
 
@@ -131,7 +131,7 @@ func (c ConnectionApi) HandleRequestPeerList(connectionId string) {
 
 // 자기자신 or 연결되어 있는 connection 제외하고 연결!!
 func (c ConnectionApi) DialConnectionList(connectionList []grpc_gateway.Connection) {
-	logger.Infof(nil, "[gRPC-Gateway] Dialing all peers in it-chain network - Total peer: [%d]", len(connectionList))
+	iLogger.Infof(nil, "[gRPC-Gateway] Dialing all peers in it-chain network - Total peer: [%d]", len(connectionList))
 
 	for _, connection := range connectionList {
 

--- a/grpc_gateway/api/message_api.go
+++ b/grpc_gateway/api/message_api.go
@@ -17,8 +17,8 @@
 package api
 
 import (
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/grpc_gateway"
+	"github.com/it-chain/iLogger"
 )
 
 type MessageApi struct {
@@ -32,6 +32,6 @@ func NewMessageApi(grpcService grpc_gateway.GrpcService) *MessageApi {
 }
 
 func (c MessageApi) DeliverMessage(body []byte, protocol string, ids ...string) {
-	logger.Infof(nil, "[gRPC-gateway] Sending grpc message - protocol: [%s] body: [%s] ids:[%s]", protocol, body, ids)
+	iLogger.Infof(nil, "[gRPC-gateway] Sending grpc message - protocol: [%s] body: [%s] ids:[%s]", protocol, body, ids)
 	c.grpcService.SendMessages(body, protocol, ids...)
 }

--- a/grpc_gateway/infra/adapter/connection_command_handler.go
+++ b/grpc_gateway/infra/adapter/connection_command_handler.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/grpc_gateway"
 	"github.com/it-chain/engine/grpc_gateway/api"
+	"github.com/it-chain/iLogger"
 )
 
 type ConnectionCommandHandler struct {
@@ -40,7 +40,7 @@ func (d *ConnectionCommandHandler) HandleCreateConnectionCommand(createConnectio
 
 	connection, err := d.connectionApi.Dial(createConnectionCommand.Address)
 	if err != nil {
-		logger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to dial - url [%s], Err: [%s]", createConnectionCommand.Address, err.Error()))
+		iLogger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to dial - url [%s], Err: [%s]", createConnectionCommand.Address, err.Error()))
 		return grpc_gateway.Connection{}, rpc.Error{Message: err.Error()}
 	}
 
@@ -51,7 +51,7 @@ func (d *ConnectionCommandHandler) HandleCloseConnectionCommand(closeConnectionC
 
 	err := d.connectionApi.CloseConnection(closeConnectionCommand.Address)
 	if err != nil {
-		logger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to close - url [%s], Err: [%s]", closeConnectionCommand.Address, err.Error()))
+		iLogger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to close - url [%s], Err: [%s]", closeConnectionCommand.Address, err.Error()))
 		return struct{}{}, rpc.Error{Message: err.Error()}
 	}
 
@@ -62,7 +62,7 @@ func (d *ConnectionCommandHandler) HandleGetConnectionListCommand(getConnectionL
 
 	connectionList, err := d.connectionApi.GetAllConnections()
 	if err != nil {
-		logger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to get connection list"))
+		iLogger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to get connection list"))
 		return command.GetConnectionList{}, rpc.Error{Message: err.Error()}
 	}
 
@@ -73,7 +73,7 @@ func (d *ConnectionCommandHandler) HandleJoinNetworkCommand(joinNetworkCommand c
 
 	err := d.connectionApi.JoinNetwork(joinNetworkCommand.Address)
 	if err != nil {
-		logger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to join network - Err: [%s]", err.Error()))
+		iLogger.Error(nil, fmt.Sprintf("[gRPC-Gateway] Fail to join network - Err: [%s]", err.Error()))
 		return struct{}{}, rpc.Error{Message: err.Error()}
 	}
 

--- a/grpc_gateway/infra/adapter/grpc_message_handler.go
+++ b/grpc_gateway/infra/adapter/grpc_message_handler.go
@@ -19,9 +19,9 @@ package adapter
 import (
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/grpc_gateway"
 	"github.com/it-chain/engine/grpc_gateway/api"
+	"github.com/it-chain/iLogger"
 )
 
 type GrpcMessageHandler struct {
@@ -40,7 +40,7 @@ func (g GrpcMessageHandler) HandleMessageReceiveEvent(command command.ReceiveGrp
 	protocol := command.Protocol
 	body := command.Body
 
-	logger.Infof(nil, "[gRPC-Gateway] Received gRPC message - Protocol [%s]", protocol)
+	iLogger.Infof(nil, "[gRPC-Gateway] Received gRPC message - Protocol [%s]", protocol)
 
 	switch protocol {
 	case grpc_gateway.RequestPeerList:
@@ -50,7 +50,7 @@ func (g GrpcMessageHandler) HandleMessageReceiveEvent(command command.ReceiveGrp
 		connectionList := []grpc_gateway.Connection{}
 
 		if err := common.Deserialize(body, &connectionList); err != nil {
-			logger.Errorf(nil, "[gRPC-Gateway] Fail to deserialize grpcMessage - Err: [%s]", err.Error())
+			iLogger.Errorf(nil, "[gRPC-Gateway] Fail to deserialize grpcMessage - Err: [%s]", err.Error())
 			return
 		}
 

--- a/grpc_gateway/infra/grpc_service.go
+++ b/grpc_gateway/infra/grpc_service.go
@@ -24,9 +24,9 @@ import (
 	"github.com/it-chain/bifrost/client"
 	"github.com/it-chain/bifrost/server"
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/grpc_gateway"
 	"github.com/it-chain/heimdall/key"
+	"github.com/it-chain/iLogger"
 )
 
 var ErrConnAlreadyExist = errors.New("connection is already exist")
@@ -140,7 +140,7 @@ func (g *GrpcHostService) onConnection(connection bifrost.Connection) {
 
 func (g *GrpcHostService) startConnectionUntilClose(connection bifrost.Connection) {
 
-	logger.Infof(nil, "[gRPC-Gateway] Handling connection - ConnectionID: [%s]", connection.GetID())
+	iLogger.Infof(nil, "[gRPC-Gateway] Handling connection - ConnectionID: [%s]", connection.GetID())
 	connection.Handle(NewMessageHandler(g.publish))
 
 	if err := connection.Start(); err != nil {
@@ -221,7 +221,7 @@ func (s *GrpcHostService) Listen(ip string) {
 }
 
 func (s *GrpcHostService) onError(err error) {
-	logger.Fatalf(nil, "[gRPC-Gateway] Connection error - [Err]: [%s]", err.Error())
+	iLogger.Fatalf(nil, "[gRPC-Gateway] Connection error - [Err]: [%s]", err.Error())
 }
 
 func (s *GrpcHostService) Stop() {
@@ -330,7 +330,7 @@ func (r MessageHandler) ServeRequest(msg bifrost.Message) {
 	})
 
 	if err != nil {
-		logger.Errorf(nil, "[gRPC-Gateway] Fail to publish message received error - [Err]: [%s]", err.Error())
+		iLogger.Errorf(nil, "[gRPC-Gateway] Fail to publish message received error - [Err]: [%s]", err.Error())
 	}
 }
 

--- a/ivm/api/icode_api.go
+++ b/ivm/api/icode_api.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/event"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/ivm"
+	"github.com/it-chain/iLogger"
 )
 
 type ICodeApi struct {
@@ -41,7 +41,7 @@ func NewICodeApi(containerService ivm.ContainerService, gitService ivm.GitServic
 }
 
 func (i ICodeApi) Deploy(id string, baseSaveUrl string, gitUrl string, sshPath string, password string) (ivm.ICode, error) {
-	logger.Info(nil, fmt.Sprintf("[IVM] Deploying icode - url: [%s]", gitUrl))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Deploying icode - url: [%s]", gitUrl))
 
 	// clone icode. in clone function, metaCreatedEvent will publish
 	icode, err := i.GitService.Clone(id, baseSaveUrl, gitUrl, sshPath, password)
@@ -59,7 +59,7 @@ func (i ICodeApi) Deploy(id string, baseSaveUrl string, gitUrl string, sshPath s
 		return ivm.ICode{}, nil
 	}
 
-	logger.Info(nil, fmt.Sprintf("[IVM] ICode has deployed - icodeID: [%s]", id))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] ICode has deployed - icodeID: [%s]", id))
 	return icode, nil
 }
 
@@ -75,7 +75,7 @@ func createMetaCreatedEvent(icode ivm.ICode) event.ICodeCreated {
 }
 
 func (i ICodeApi) UnDeploy(id ivm.ID) error {
-	logger.Info(nil, fmt.Sprintf("[IVM] Undeploying icode - icodeID: [%s]", id))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Undeploying icode - icodeID: [%s]", id))
 	// stop iCode container
 	err := i.ContainerService.StopContainer(id)
 
@@ -83,7 +83,7 @@ func (i ICodeApi) UnDeploy(id ivm.ID) error {
 		return err
 	}
 
-	logger.Info(nil, fmt.Sprintf("[IVM] Icode has undeployed - icodeID: [%s] ", id))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Icode has undeployed - icodeID: [%s] ", id))
 
 	return i.EventService.Publish("icode.deleted", event.ICodeDeleted{ICodeID: id})
 }
@@ -97,7 +97,7 @@ func (i ICodeApi) ExecuteRequestList(RequestList []ivm.Request) []ivm.Result {
 		result, err := i.ExecuteRequest(request)
 
 		if err != nil {
-			logger.Error(nil, fmt.Sprintf("[IVM] Fail to invoke icode - message: [%s] ", err.Error()))
+			iLogger.Error(nil, fmt.Sprintf("[IVM] Fail to invoke icode - message: [%s] ", err.Error()))
 			result = ivm.Result{Err: err.Error()}
 		}
 

--- a/ivm/infra/adapter/deploy_command_handler.go
+++ b/ivm/infra/adapter/deploy_command_handler.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/it-chain/iLogger"
+
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/ivm"
 	"github.com/it-chain/engine/ivm/api"
@@ -44,7 +45,7 @@ func (d *DeployCommandHandler) HandleDeployCommand(deployCommand command.Deploy)
 	icode, err := d.icodeApi.Deploy(deployCommand.ICodeId, savePath, deployCommand.Url, sshPath, deployCommand.Password)
 
 	if err != nil {
-		logger.Error(nil, fmt.Sprintf("[Icode] fail to deploy ivm, url %s", deployCommand.Url))
+		iLogger.Error(nil, fmt.Sprintf("[Icode] fail to deploy ivm, url %s", deployCommand.Url))
 		return ivm.ICode{}, rpc.Error{Message: err.Error()}
 	}
 

--- a/ivm/infra/git/icode_git_store.go
+++ b/ivm/infra/git/icode_git_store.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/ivm"
+	"github.com/it-chain/iLogger"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
@@ -45,7 +45,7 @@ func NewRepositoryService() *RepositoryService {
 }
 
 func (gApi *RepositoryService) Clone(id string, baseSavePath string, repositoryUrl string, sshPath string, password string) (ivm.ICode, error) {
-	logger.Info(nil, fmt.Sprintf("[IVM] Cloning Icode - url: [%s]", repositoryUrl))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Cloning Icode - url: [%s]", repositoryUrl))
 
 	gitUrl, err := toGitUrl(repositoryUrl, sshPath)
 	if err != nil {
@@ -114,7 +114,7 @@ func (gApi *RepositoryService) Clone(id string, baseSavePath string, repositoryU
 		return nil
 	})
 
-	logger.Info(nil, fmt.Sprintf("[IVM] ICode has successfully cloned - url: [%s], icodeID: [%s], version[%s]", repositoryUrl, id, version))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] ICode has successfully cloned - url: [%s], icodeID: [%s], version[%s]", repositoryUrl, id, version))
 
 	metaData := ivm.NewICode(id, name, repositoryUrl, baseSavePath+"/"+name, commitHash, version)
 	return metaData, nil

--- a/ivm/infra/tesseract/container_service.go
+++ b/ivm/infra/tesseract/container_service.go
@@ -23,8 +23,8 @@ import (
 
 	"sync"
 
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/ivm"
+	"github.com/it-chain/iLogger"
 	"github.com/it-chain/tesseract"
 	"github.com/it-chain/tesseract/container"
 	"github.com/it-chain/tesseract/pb"
@@ -52,7 +52,7 @@ func NewContainerService() *ContainerService {
 }
 
 func (cs ContainerService) StartContainer(icode ivm.ICode) error {
-	logger.Info(nil, fmt.Sprintf("[IVM] Starting container - icodeID: [%s]", icode.ID))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Starting container - icodeID: [%s]", icode.ID))
 	cs.Lock()
 	defer cs.Unlock()
 
@@ -84,7 +84,7 @@ func (cs ContainerService) StartContainer(icode ivm.ICode) error {
 }
 
 func (cs ContainerService) ExecuteRequest(request ivm.Request) (ivm.Result, error) {
-	logger.Info(nil, fmt.Sprintf("[IVM] Executing icode - icodeID: [%s]", request.ICodeID))
+	iLogger.Info(nil, fmt.Sprintf("[IVM] Executing icode - icodeID: [%s]", request.ICodeID))
 
 	iCodeInfo, ok := cs.iCodeInfoMap[request.ICodeID]
 	if !ok {
@@ -126,7 +126,7 @@ func (cs ContainerService) ExecuteRequest(request ivm.Request) (ivm.Result, erro
 
 	select {
 	case err := <-errCh:
-		logger.Error(nil, fmt.Sprintf("[IVM] fail executing ivm, id:%s", request.ICodeID))
+		iLogger.Error(nil, fmt.Sprintf("[IVM] fail executing ivm, id:%s", request.ICodeID))
 		return ivm.Result{}, err
 	case result := <-resultCh:
 		return result, nil

--- a/p2p/election.go
+++ b/p2p/election.go
@@ -19,7 +19,7 @@ package p2p
 import (
 	"sync"
 
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 )
 
 const Candidate = "Candidate"
@@ -55,7 +55,7 @@ func (election *Election) SetLeftTime() int {
 }
 
 func (election *Election) ResetLeftTime() {
-	logger.Infof(nil, "reset lefttime from %s", election.ipAddress)
+	iLogger.Infof(nil, "reset lefttime from %s", election.ipAddress)
 
 	election.mux.Lock()
 	defer election.mux.Unlock()
@@ -78,7 +78,7 @@ func (election *Election) SetState(state string) {
 	election.mux.Lock()
 	defer election.mux.Unlock()
 
-	logger.Infof(nil, "set state to: %s", state)
+	iLogger.Infof(nil, "set state to: %s", state)
 
 	election.state = state
 }

--- a/p2p/election_service.go
+++ b/p2p/election_service.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 	"github.com/rs/xid"
 )
 
@@ -74,7 +74,7 @@ func (es *ElectionService) Vote(connectionId string) error {
 
 // broadcast leader to other peers
 func (es *ElectionService) BroadcastLeader(peer Peer) error {
-	logger.Info(nil, "[P2P] Broadcast leader")
+	iLogger.Info(nil, "[P2P] Broadcast leader")
 
 	updateLeaderMessage := UpdateLeaderMessage{
 		Peer: peer,
@@ -140,12 +140,12 @@ func (es *ElectionService) ElectLeaderWithRaft() {
 			select {
 
 			case <-timeout:
-				logger.Info(nil, "timed out!")
+				iLogger.Info(nil, "timed out!")
 				// when timed out
 				// 1. if state is ticking, be candidate and request vote
 				// 2. if state is candidate, reset state and left time
 				if es.Election.GetState() == Ticking {
-					logger.Infof(nil, "candidate process: %v", es.Election.candidate)
+					iLogger.Infof(nil, "candidate process: %v", es.Election.candidate)
 					es.Election.SetState(Candidate)
 
 					pLTable, _ := es.peerQueryService.GetPLTable()

--- a/p2p/infra/adapter/grpc_command_handler.go
+++ b/p2p/infra/adapter/grpc_command_handler.go
@@ -19,9 +19,10 @@ package adapter
 import (
 	"errors"
 
+	"github.com/it-chain/iLogger"
+
 	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/p2p"
 	"github.com/it-chain/engine/p2p/api"
 )
@@ -68,7 +69,7 @@ func (gch *GrpcCommandHandler) HandleMessageReceive(command command.ReceiveGrpc)
 		break
 
 	case "RequestVoteProtocol":
-		logger.Infof(nil, "handling request vote from process: %v", gch.electionService.Election.GetIpAddress())
+		iLogger.Infof(nil, "handling request vote from process: %v", gch.electionService.Election.GetIpAddress())
 		gch.electionService.Vote(command.ConnectionID)
 
 	case "VoteLeaderProtocol":
@@ -99,5 +100,3 @@ func (gch *GrpcCommandHandler) HandleMessageReceive(command command.ReceiveGrpc)
 
 	return nil
 }
-
-//

--- a/p2p/test/service.go
+++ b/p2p/test/service.go
@@ -19,12 +19,12 @@ package test
 import (
 	"github.com/it-chain/avengers/mock"
 	"github.com/it-chain/engine/api_gateway"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/p2p"
 	"github.com/it-chain/engine/p2p/api"
 	"github.com/it-chain/engine/p2p/infra/adapter"
 	"github.com/it-chain/engine/p2p/infra/mem"
 	mock2 "github.com/it-chain/engine/p2p/test/mock"
+	"github.com/it-chain/iLogger"
 )
 
 type ProcessIdentity struct {
@@ -78,7 +78,7 @@ func SetTestEnvironment(processList []ProcessIdentity) map[string]*mock.Process 
 		m[process.Id] = &process
 	}
 
-	logger.Infof(nil, "created process: %v", m)
+	iLogger.Infof(nil, "created process: %v", m)
 	return m
 }
 

--- a/txpool/infra/adapter/block_propose_service.go
+++ b/txpool/infra/adapter/block_propose_service.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 
 	"github.com/it-chain/engine/common/command"
-	"github.com/it-chain/engine/common/logger"
 	"github.com/it-chain/engine/common/rabbitmq/rpc"
 	"github.com/it-chain/engine/txpool"
+	"github.com/it-chain/iLogger"
 	"github.com/rs/xid"
 )
 
@@ -105,11 +105,11 @@ func (b BlockProposalService) sendBlockProposal(transactions []txpool.Transactio
 	err := b.client.Call("block.propose", proposeCommand, func(_ struct{}, err rpc.Error) {
 
 		if !err.IsNil() {
-			logger.Fatal(nil, err.Message)
+			iLogger.Fatal(nil, err.Message)
 			return
 		}
 
-		logger.Infof(nil, "[Txpool] Block has proposed")
+		iLogger.Infof(nil, "[Txpool] Block has proposed")
 	})
 
 	return err

--- a/txpool/infra/batch/timeout_batcher.go
+++ b/txpool/infra/batch/timeout_batcher.go
@@ -21,7 +21,7 @@ import (
 
 	"sync"
 
-	"github.com/it-chain/engine/common/logger"
+	"github.com/it-chain/iLogger"
 )
 
 var instance *TimeoutBatcher
@@ -58,7 +58,7 @@ func (t *Task) Start() error {
 		select {
 		case <-t.T.C:
 			if err := t.taskFunc(); err != nil {
-				logger.Error(nil, "error: "+err.Error())
+				iLogger.Error(nil, "error: "+err.Error())
 			}
 		case <-t.quit:
 			t.Stop()
@@ -95,7 +95,7 @@ func (t *TimeoutBatcher) Run(taskFunc TaskFunc, duration time.Duration) chan str
 		err = timer.Start()
 
 		if err != nil {
-			logger.Error(nil, "error: "+err.Error())
+			iLogger.Error(nil, "error: "+err.Error())
 			//	return
 		}
 	}()


### PR DESCRIPTION
resolved: #823 

details:
기존 log 사용 시 common/logger package를 사용하였으나 iLogger library로 변경하였습니다.
engin의 common/logger 폴더를 삭제 하지 않았습니다. 
p2p 테스트 부분에서 avengers 라이브러리를 사용하는데 common/logger를 사용하고 있습니다. 
engine 적용 후 avengers에서 common/logger부분을 수정 이후에 common/logger package를 삭제 해야 될 것으로 판단됩니다.

avengers 사용 위치 :  ./p2p/test/service.go -> avengers/mock/network_manager.go


[task detail...]

1. [task1]
2. [task2]