### PR TITLE
[cmd] add debug mode global option(cli)

### DIFF
--- a/doc/IT-CHAIN-CLI.md
+++ b/doc/IT-CHAIN-CLI.md
@@ -13,7 +13,7 @@ USAGE:
 ## GLOBAL OPTIONS
 - --config value : explicit set config file 
 ```
-[root@it-chain engine]# it-chain ./conf/config.yaml
+[root@it-chain engine]# it-chain --config explicit_config_file.yaml
 
         ___  _________               ________  ___  ___  ________  ___  ________
         |\  \|\___   ___\            |\   ____\|\  \|\  \|\   __  \|\  \|\   ___  \
@@ -24,6 +24,13 @@ USAGE:
             \|__|    \|__|               \|_______|\|__|\|__|\|__|\|__|\|__|\|__| \|__|
 ...
 ```
+
+- --debug : set debug mode
+```
+[root@it-chain engine]# it-chain --debug
+DEBU[2018-09-29T20:53:28+09:00] You can see debug log because you called global options debug.
+```
+
 - --help, -h : show help
 ```
 [root@it-chain engine]# it-chain -h
@@ -46,6 +53,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --config value  name for config
+   --debug         set debug mode
    --help, -h      show help
    --version, -v   print the version
 ```

--- a/it-chain.go
+++ b/it-chain.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/it-chain/iLogger"
+
 	"github.com/it-chain/engine/cmd/connection"
 	"github.com/it-chain/engine/cmd/ivm"
 	"github.com/it-chain/engine/cmd/on"
@@ -47,6 +49,10 @@ func main() {
 			Value: "",
 			Usage: "name for config",
 		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "set debug mode",
+		},
 	}
 	app.Commands = []cli.Command{}
 	app.Commands = append(app.Commands, ivm.IcodeCmd())
@@ -59,6 +65,11 @@ func main() {
 			}
 			conf.SetConfigPath(absPath)
 		}
+
+		if c.Bool("debug") {
+			iLogger.SetToDebug()
+		}
+
 		return nil
 	}
 	app.Action = on.Action


### PR DESCRIPTION
resolved: #863  

details:
- add debug mode option when you start engin (You can use debug logger)
ex) $ it-chain --debug

[task detail...]

1. [task1]
2. [task2]

