### PR TITLE
[consensus] #960 Refactor LeaderEventHandler HandleLeaderDeletedEvent

### DIFF
--- a/consensus/pbft/api/election_api_test.go
+++ b/consensus/pbft/api/election_api_test.go
@@ -237,6 +237,14 @@ func TestElectionApi_GetVoteCount(t *testing.T) {
 	assert.Equal(t, api.GetVoteCount(), 0)
 }
 
+func TestElectionApi_IsElectionNeed(t *testing.T) {
+
+}
+
+func TestElectionApi_ElectLeaderWithLargestRepresentativeId(t *testing.T) {
+
+}
+
 func setElectionApi() *api.ElectionApi {
 
 	electionService := pbft.NewElectionService("1", 30, pbft.NORMAL, 0)

--- a/consensus/pbft/infra/adapter/leader_event_handler.go
+++ b/consensus/pbft/infra/adapter/leader_event_handler.go
@@ -17,7 +17,6 @@
 package adapter
 
 import (
-	"github.com/it-chain/engine/common"
 	"github.com/it-chain/engine/common/event"
 	"github.com/it-chain/engine/consensus/pbft/api"
 	"github.com/it-chain/iLogger"
@@ -35,18 +34,6 @@ func NewLeaderEventHandler(electionApi *api.ElectionApi) *LeaderEventHandler {
 
 func (l *LeaderEventHandler) HandlerLeaderDeletedEvent(_ event.LeaderDeleted) {
 	iLogger.Infof(nil, "[PBFT] Leader Deleted, Start Elect Leader With RAFT")
-
-	representatives := l.electionApi.GetParliament().GetRepresentatives()
-
-	ids := make([]string, 0)
-	for _, rep := range representatives {
-		ids = append(ids, rep.ID)
-	}
-
-	if len(representatives) < 3 {
-		l.electionApi.SetLeader(common.FindEarliestString(ids))
-		return
-	}
 
 	go l.electionApi.ElectLeaderWithRaft()
 }


### PR DESCRIPTION
resolved: #960 

details:

Hide all the logic into ElectLeaderWithRaft

```go
func (e *ElectionApi) ElectLeaderWithRaft() {
	if !e.IsElectionNeed() {
		e.ElectLeaderWithLargestRepresentativeId()
		return
	}
        ...
}
```
기존에 HandleLeaderDeletedEvent가 하는 일이 representative가 3명보다 작을 때 가장 큰 아이디의 representative를 리더로 뽑는 것이어서 그 로직을 ElectLeaderWithRaft 앞으로 옮겼습니다.

\+ update

지금 보니까 `IsElectionNeed` 함수 parliament 도메인 함수로 빼는게 더 좋아보이네요..

\+ update2

parliament 함수에 `IsConsensusNeed` 함수가 있었네요ㅋㅋ 수정하겠습니다

 - [ ] Test case
