### PR TITLE
Blockchain/fixbug/merkletree

### DIFF
--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -42,6 +42,7 @@ type DefaultBlock struct {
 	PrevSeal  []byte
 	Height    uint64
 	TxList    []*DefaultTransaction
+	Tree      *Tree
 	TxSeal    [][]byte
 	Timestamp time.Time
 	Creator   string
@@ -78,6 +79,10 @@ func (block *DefaultBlock) SetTxSeal(txSeal [][]byte) {
 	block.TxSeal = txSeal
 }
 
+func (block *DefaultBlock) SetTree(tree *Tree) {
+	block.Tree = tree
+}
+
 func (block *DefaultBlock) SetCreator(creator string) {
 	block.Creator = creator
 }
@@ -110,6 +115,10 @@ func (block *DefaultBlock) GetTxList() []Transaction {
 	return txList
 }
 
+func (block *DefaultBlock) GetTree() *Tree {
+	return block.Tree
+}
+
 func (block *DefaultBlock) GetTxSeal() [][]byte {
 	return block.TxSeal
 }
@@ -124,6 +133,10 @@ func (block *DefaultBlock) GetTimestamp() time.Time {
 
 func (block *DefaultBlock) GetState() BlockState {
 	return block.State
+}
+
+func (block *DefaultBlock) GetTxSealRoot() []byte {
+	return block.Tree.txSealRoot
 }
 
 // TODO: Write test case

--- a/blockchain/block_factory.go
+++ b/blockchain/block_factory.go
@@ -37,7 +37,7 @@ func CreateGenesisBlock(genesisconfFilePath string) (DefaultBlock, error) {
 	}
 
 	//build
-	Seal, err := validator.BuildSeal(GenesisBlock.Timestamp, GenesisBlock.PrevSeal, GenesisBlock.TxSeal, GenesisBlock.Creator)
+	Seal, err := validator.BuildSeal(GenesisBlock.Timestamp, GenesisBlock.PrevSeal, GenesisBlock.Tree.txSealRoot, GenesisBlock.Creator)
 
 	if err != nil {
 		return DefaultBlock{}, ErrBuildingSeal
@@ -83,7 +83,12 @@ func setBlockWithConfig(filePath string, block *DefaultBlock) error {
 
 	block.SetPrevSeal(make([]byte, 0))
 	block.SetHeight(uint64(GenesisConfig.Height))
+
+	//ToDo: 지우기
 	block.SetTxSeal(make([][]byte, 0))
+
+	//ToDo: &Tree{}가 최선인가... : txList가 없어도, build tree 해주고 그 tree를 넣어줘야 함.
+	block.SetTree(&Tree{})
 	block.SetTimestamp(timeStamp)
 	block.SetCreator(GenesisConfig.Creator)
 	block.SetState(Created)
@@ -113,11 +118,13 @@ func CreateProposedBlock(prevSeal []byte, height uint64, txList []*DefaultTransa
 
 	txSeal, err := validator.BuildTxSeal(ConvertTxType(txList))
 
+	tree, err := validator.BuildTree(ConvertTxType(txList))
+
 	if err != nil {
 		return DefaultBlock{}, ErrBuildingTxSeal
 	}
 
-	Seal, err := validator.BuildSeal(TimeStamp, prevSeal, txSeal, Creator)
+	Seal, err := validator.BuildSeal(TimeStamp, prevSeal, tree.txSealRoot, Creator)
 
 	if err != nil {
 		return DefaultBlock{}, ErrBuildingSeal
@@ -128,6 +135,7 @@ func CreateProposedBlock(prevSeal []byte, height uint64, txList []*DefaultTransa
 	ProposedBlock.SetPrevSeal(prevSeal)
 	ProposedBlock.SetHeight(height)
 	ProposedBlock.SetTxSeal(txSeal)
+	ProposedBlock.SetTree(tree)
 	ProposedBlock.SetTimestamp(TimeStamp)
 	ProposedBlock.SetCreator(Creator)
 	ProposedBlock.SetState(Created)

--- a/blockchain/test/mock/mock_data.go
+++ b/blockchain/test/mock/mock_data.go
@@ -17,11 +17,13 @@
 package mock
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/it-chain/engine/blockchain"
 	"github.com/it-chain/engine/common/command"
 	"github.com/it-chain/yggdrasill/common"
+	"github.com/rs/xid"
 )
 
 func GetTxResults() []command.TxResult {
@@ -96,10 +98,35 @@ func GetNewBlock(prevSeal []byte, height uint64) *blockchain.DefaultBlock {
 	txSeal, _ := validator.BuildTxSeal(ConvertTxListType(txList))
 	block.SetTxSeal(txSeal)
 
-	seal, _ := validator.BuildSeal(block.GetTimestamp(), block.GetPrevSeal(), block.GetTxSeal(), block.GetCreator())
+	seal, _ := validator.BuildSeal(block.GetTimestamp(), block.GetPrevSeal(), block.GetTxSealRoot(), block.GetCreator())
 	block.SetSeal(seal)
 
 	return block
+}
+
+func GetRandomTxList() []*blockchain.DefaultTransaction {
+	randSource := rand.NewSource(time.Now().UnixNano())
+	randInstance := rand.New(randSource)
+	randomTxListLength := randInstance.Intn(100)
+
+	TxList := []*blockchain.DefaultTransaction{}
+
+	for i := 0; i <= randomTxListLength; i++ {
+		Tx := &blockchain.DefaultTransaction{
+			ID:        xid.New().String(),
+			ICodeID:   xid.New().String(),
+			PeerID:    xid.New().String(),
+			Timestamp: time.Now().Round(0),
+			Jsonrpc:   xid.New().String(),
+			Function:  xid.New().String(),
+			Args:      nil,
+			Signature: []byte(xid.New().String()),
+		}
+
+		TxList = append(TxList, Tx)
+	}
+
+	return TxList
 }
 
 func GetTxList(testingTime time.Time) []*blockchain.DefaultTransaction {

--- a/blockchain/validator.go
+++ b/blockchain/validator.go
@@ -18,10 +18,9 @@ package blockchain
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"time"
-
-	"crypto/sha256"
 
 	"github.com/it-chain/yggdrasill/common"
 )

--- a/blockchain/validator_test.go
+++ b/blockchain/validator_test.go
@@ -17,10 +17,12 @@
 package blockchain_test
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/it-chain/engine/blockchain"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -103,5 +105,38 @@ func TestDefaultValidator_BuildAndValidateTxSeal(t *testing.T) {
 	//then
 	assert.NoError(t, err)
 	assert.Equal(t, true, result2)
+
+}
+
+func TestDefaultValidator_BuildTreeAndValidate(t *testing.T) {
+	validator := blockchain.DefaultValidator{}
+
+	randSource := rand.NewSource(time.Now().UnixNano())
+	randInstance := rand.New(randSource)
+	randomTxListLength := randInstance.Intn(100)
+
+	TxList := []*blockchain.DefaultTransaction{}
+
+	for i := 0; i <= randomTxListLength; i++ {
+		Tx := &blockchain.DefaultTransaction{
+			ID:        xid.New().String(),
+			ICodeID:   xid.New().String(),
+			PeerID:    xid.New().String(),
+			Timestamp: time.Now().Round(0),
+			Jsonrpc:   xid.New().String(),
+			Function:  xid.New().String(),
+			Args:      nil,
+			Signature: []byte(xid.New().String()),
+		}
+
+		TxList = append(TxList, Tx)
+	}
+
+	tree, err := validator.BuildTree(convertTxType(TxList))
+	assert.NoError(t, err)
+
+	isValidated, err := validator.ValidateTree(tree)
+	assert.NoError(t, err)
+	assert.Equal(t, true, isValidated)
 
 }

--- a/ivm/mock/vendor/github.com/it-chain/sdk/logger/log_wrapper.go
+++ b/ivm/mock/vendor/github.com/it-chain/sdk/logger/log_wrapper.go
@@ -18,13 +18,10 @@
 package logger
 
 import (
-	"os"
-
 	"fmt"
-
-	"runtime"
-
+	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 )

--- a/ivm/mock/vendor/github.com/syndtr/goleveldb/leveldb/table/reader.go
+++ b/ivm/mock/vendor/github.com/syndtr/goleveldb/leveldb/table/reader.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	"github.com/golang/snappy"
-
 	"github.com/syndtr/goleveldb/leveldb/cache"
 	"github.com/syndtr/goleveldb/leveldb/comparer"
 	"github.com/syndtr/goleveldb/leveldb/errors"

--- a/ivm/mock/vendor/github.com/syndtr/goleveldb/leveldb/table/writer.go
+++ b/ivm/mock/vendor/github.com/syndtr/goleveldb/leveldb/table/writer.go
@@ -13,7 +13,6 @@ import (
 	"io"
 
 	"github.com/golang/snappy"
-
 	"github.com/syndtr/goleveldb/leveldb/comparer"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"

--- a/ivm/mock/vendor/google.golang.org/grpc/internal/transport/go16.go
+++ b/ivm/mock/vendor/google.golang.org/grpc/internal/transport/go16.go
@@ -24,10 +24,9 @@ import (
 	"net"
 	"net/http"
 
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"golang.org/x/net/context"
 )
 
 // dialContext connects to the address on the named network.

--- a/ivm/mock/vendor/google.golang.org/grpc/internal/transport/go17.go
+++ b/ivm/mock/vendor/google.golang.org/grpc/internal/transport/go17.go
@@ -25,10 +25,9 @@ import (
 	"net"
 	"net/http"
 
+	netctx "golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	netctx "golang.org/x/net/context"
 )
 
 // dialContext connects to the address on the named network.

--- a/ivm/mock/vendor/google.golang.org/grpc/internal/transport/http2_client.go
+++ b/ivm/mock/vendor/google.golang.org/grpc/internal/transport/http2_client.go
@@ -31,7 +31,6 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"

--- a/ivm/mock/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/ivm/mock/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -34,7 +34,6 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"

--- a/ivm/mock/vendor/google.golang.org/grpc/server.go
+++ b/ivm/mock/vendor/google.golang.org/grpc/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"net"
 	"net/http"
@@ -32,12 +33,9 @@ import (
 	"sync"
 	"time"
 
-	"io/ioutil"
-
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/trace"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"


### PR DESCRIPTION
resolved: #946 

details:

레퍼런스에서는 build tree를 할 때, 매번 새로운 리프를 만들 때마다 홀수인지 체크하여 홀수라면 마지막 리프를 복사해서 짝수로 만들어주고 있습니다.(실제로 복사는 안하는데 이해하기 쉽게 하기위해...)

근데 우리는 이제까지 맨 처음에만 +1을 해주고, 다음에는 체크를 안했습니다.
그래서 6개 같은 경우에는 다음에 3개가 나오니까 또 홀수라서 에러가 걸립니다.

build tree 부분을 해결하는거는 쉬운데,
validate 부분 수정을 바꾸려다보니까 많이 바뀌었는데요

현재 우리는 validate를 리프의 개수를 안다는 전제하에 하고 있습니다.
그런데 build tree가 바뀌면 tx 개수가 몇개인지에 따라 전체 리프의 개수를 알 수가 없게되죠.
그래서 레퍼런스에서는 validate 할 때 재귀를 써서 연결돼있는 애들을 다 다시 검증하는 식으로 하고 있습니다.

이 부분을 바꿔주는 게 핵심이었고,

그러다보니 Tree 객체가 생겼습니다.

현재 테스트는 transaction 개수를 100개 이하 랜덤으로 체크해주고있고,

이게 block쪽에 적용이되면

이제는 block 객체에서 txSeal을 갖는 게 아니라
Tree 객체를 갖던지, Tree를 serialize한 값을 가져야 할 것 같습니다.

 - [x] Test case
