### PR TITLE
Fix ivm list formatting

### DIFF
--- a/cmd/ivm/list.go
+++ b/cmd/ivm/list.go
@@ -52,7 +52,7 @@ func list() {
 			return
 		}
 
-		fmt.Println("Index\t ID\t\t\t Version\t GitUrl")
+		fmt.Println("Index\t ID\t\t\t\t\t\t\t Version\t GitUrl")
 		for index, iCodes := range ICodeList.ICodes {
 			fmt.Printf("[%d]\t [%s]\t [%s]\t\t [%s]\n",
 				index, iCodes.ID, iCodes.Version, iCodes.GitUrl)


### PR DESCRIPTION
details:
Indentation is not correct when printing `it-chain ivm list`