### PR TITLE
Pbft msgpool fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -252,7 +252,6 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:ce991deca7e031696427c674b19a27b78e1dc846befdc3f4efa343aa0bdc0bb4"
   name = "github.com/it-chain/tesseract"
   packages = [
     ".",
@@ -261,10 +260,8 @@
     "pb",
     "rpc"
   ]
-  pruneopts = "UT"
   revision = "42009954a730be377a90f50ddd71a5f331188892"
   version = "v0.4.4"
-
 
 [[projects]]
   name = "github.com/it-chain/yggdrasill"
@@ -786,6 +783,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "553d242fc508c70523b2188c3a8d1d76486329a3e1455a27de852ba075c8e371"
+  inputs-digest = "166bf3d67e8774a122af9ee5741a61504a10bcc0e469610ae61eb0d695507b0a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/consensus/pbft/api/state_api.go
+++ b/consensus/pbft/api/state_api.go
@@ -220,23 +220,27 @@ func (s *StateApi) checkPreCommit(state pbft.State) pbft.State {
 }
 
 func (s *StateApi) updatePrevoteMsgPool(loadedState pbft.State) pbft.State {
-	for _, poolMsg := range s.tempPrevoteMsgPool.Get() {
-		if err := loadedState.PrevoteMsgPool.Save(&poolMsg); err != nil {
+	for _, poolMsg := range s.tempPrevoteMsgPool.FindAll() {
+		if err := loadedState.SavePrevoteMsg(&poolMsg); err != nil {
 			iLogger.Debugf(nil, "[PBFT] Saving prevote msg is failed - Error: [%s]", err)
+			continue
 		}
+
+		s.tempPrevoteMsgPool.Remove(poolMsg.MsgID)
 	}
-	s.tempPrevoteMsgPool.RemoveAllMsgs()
 
 	return loadedState
 }
 
 func (s *StateApi) updatePreCommitMsgPool(loadedState pbft.State) pbft.State {
-	for _, poolMsg := range s.tempPreCommitMsgPool.Get() {
-		if err := loadedState.PreCommitMsgPool.Save(&poolMsg); err != nil {
+	for _, poolMsg := range s.tempPreCommitMsgPool.FindAll() {
+		if err := loadedState.SavePreCommitMsg(&poolMsg); err != nil {
 			iLogger.Debugf(nil, "[PBFT] Saving precommit msg is failed - Error: [%s]", err)
+			continue
 		}
+
+		s.tempPreCommitMsgPool.Remove(poolMsg.MsgID)
 	}
-	s.tempPreCommitMsgPool.RemoveAllMsgs()
 
 	return loadedState
 }

--- a/consensus/pbft/api/state_api_intenal_test.go
+++ b/consensus/pbft/api/state_api_intenal_test.go
@@ -150,12 +150,14 @@ func TestStateApi_Reflect_TemporaryPrevoteMsgPool(t *testing.T) {
 	}
 
 	var tempPrevoteMsg = pbft.PrevoteMsg{
+		MsgID:     "m1",
 		StateID:   pbft.StateID{"state"},
 		SenderID:  "user1",
 		BlockHash: []byte{1, 2, 3, 5},
 	}
 
 	var tempPrevoteMsg2 = pbft.PrevoteMsg{
+		MsgID:     "m2",
 		StateID:   pbft.StateID{"state"},
 		SenderID:  "user2",
 		BlockHash: []byte{1, 2, 3, 5},
@@ -167,13 +169,13 @@ func TestStateApi_Reflect_TemporaryPrevoteMsgPool(t *testing.T) {
 
 	stateApi.ReceivePrevote(tempPrevoteMsg)
 
-	assert.Equal(t, 1, len(stateApi.tempPrevoteMsgPool.Get()))
+	assert.Equal(t, 1, len(stateApi.tempPrevoteMsgPool.FindAll()))
 
 	stateApi.AcceptProposal(tempProposeMsg)
 	stateApi.ReceivePrevote(tempPrevoteMsg2)
 
 	state, _ := stateApi.stateRepository.Load()
-	assert.Equal(t, 2, len(state.PrevoteMsgPool.Get()))
+	assert.Equal(t, 2, len(state.PrevoteMsgPool.FindAll()))
 
 }
 
@@ -193,11 +195,13 @@ func TestStateApi_Reflect_TemporaryPreCommitMsgPool(t *testing.T) {
 	}
 
 	var tempPreCommitMsg = pbft.PreCommitMsg{
+		MsgID:    "m1",
 		StateID:  pbft.StateID{"state"},
 		SenderID: "user1",
 	}
 
 	var tempPreCommitMsg2 = pbft.PreCommitMsg{
+		MsgID:    "m2",
 		StateID:  pbft.StateID{"state"},
 		SenderID: "user2",
 	}
@@ -207,12 +211,12 @@ func TestStateApi_Reflect_TemporaryPreCommitMsgPool(t *testing.T) {
 	stateApi.stateRepository.Remove()
 
 	stateApi.ReceivePreCommit(tempPreCommitMsg)
-	assert.Equal(t, 1, len(stateApi.tempPreCommitMsgPool.Get()))
+	assert.Equal(t, 1, len(stateApi.tempPreCommitMsgPool.FindAll()))
 
 	stateApi.AcceptProposal(tempProposeMsg)
 	stateApi.ReceivePreCommit(tempPreCommitMsg2)
 	state, _ := stateApi.stateRepository.Load()
-	assert.Equal(t, 2, len(state.PreCommitMsgPool.Get()))
+	assert.Equal(t, 2, len(state.PreCommitMsgPool.FindAll()))
 
 }
 
@@ -230,6 +234,7 @@ func TestStateApi_checkPrevote(t *testing.T) {
 		senderStr := "user"
 		senderStr += string(i)
 		prevoteMsgPool.Save(&pbft.PrevoteMsg{
+			MsgID:     "m" + string(i),
 			StateID:   pbft.StateID{"state"},
 			SenderID:  senderStr,
 			BlockHash: []byte{1, 2, 3, 4},
@@ -256,6 +261,7 @@ func TestStateApi_checkPreCommit(t *testing.T) {
 		senderStr := "user"
 		senderStr += string(i)
 		precommitMsgPool.Save(&pbft.PreCommitMsg{
+			MsgID:    "m" + string(i),
 			StateID:  pbft.StateID{"state"},
 			SenderID: senderStr,
 		})
@@ -292,6 +298,7 @@ func TestStateApi_updatePrevoteMsgPool(t *testing.T) {
 	msgNum := 2
 	for i := 0; i < msgNum; i++ {
 		msg := pbft.PrevoteMsg{
+			MsgID:     "m" + string(i),
 			StateID:   pbft.StateID{"sid"},
 			SenderID:  string(i),
 			BlockHash: []byte{'h', 'a', 's', 'h'},
@@ -299,15 +306,15 @@ func TestStateApi_updatePrevoteMsgPool(t *testing.T) {
 		stateApi.tempPrevoteMsgPool.Save(&msg)
 	}
 
-	assert.Equal(t, msgNum, len(stateApi.tempPrevoteMsgPool.Get()))
+	assert.Equal(t, msgNum, len(stateApi.tempPrevoteMsgPool.FindAll()))
 
 	// when
 	loadedState, _ := stateApi.stateRepository.Load()
 	loadedState = stateApi.updatePrevoteMsgPool(loadedState)
 
 	// then
-	assert.Equal(t, 0, len(stateApi.tempPrevoteMsgPool.Get()))
-	assert.Equal(t, msgNum, len(loadedState.PrevoteMsgPool.Get()))
+	assert.Equal(t, 0, len(stateApi.tempPrevoteMsgPool.FindAll()))
+	assert.Equal(t, msgNum, len(loadedState.PrevoteMsgPool.FindAll()))
 }
 
 func TestStateApi_updatePreCommitMsgPool(t *testing.T) {
@@ -335,21 +342,22 @@ func TestStateApi_updatePreCommitMsgPool(t *testing.T) {
 	msgNum := 3
 	for i := 0; i < msgNum; i++ {
 		msg := pbft.PreCommitMsg{
+			MsgID:    "m" + string(i),
 			StateID:  pbft.StateID{"sid"},
 			SenderID: string(i),
 		}
 		stateApi.tempPreCommitMsgPool.Save(&msg)
 	}
 
-	assert.Equal(t, msgNum, len(stateApi.tempPreCommitMsgPool.Get()))
+	assert.Equal(t, msgNum, len(stateApi.tempPreCommitMsgPool.FindAll()))
 
 	// when
 	loadedState, _ := stateApi.stateRepository.Load()
 	loadedState = stateApi.updatePreCommitMsgPool(loadedState)
 
 	// then
-	assert.Equal(t, 0, len(stateApi.tempPreCommitMsgPool.Get()))
-	assert.Equal(t, msgNum, len(loadedState.PreCommitMsgPool.Get()))
+	assert.Equal(t, 0, len(stateApi.tempPreCommitMsgPool.FindAll()))
+	assert.Equal(t, msgNum, len(loadedState.PreCommitMsgPool.FindAll()))
 }
 
 func setUpApiCondition(peerNum int, isRepoFull, isNormalBlock bool, stage pbft.Stage) *StateApi {

--- a/consensus/pbft/api/state_api_intenal_test.go
+++ b/consensus/pbft/api/state_api_intenal_test.go
@@ -232,9 +232,9 @@ func TestStateApi_checkPrevote(t *testing.T) {
 	prevoteMsgPool := pbft.NewPrevoteMsgPool()
 	for i := 1; i < 6; i++ {
 		senderStr := "user"
-		senderStr += string(i)
+		senderStr += strconv.Itoa(i)
 		prevoteMsgPool.Save(&pbft.PrevoteMsg{
-			MsgID:     "m" + string(i),
+			MsgID:     "m" + strconv.Itoa(i),
 			StateID:   pbft.StateID{"state"},
 			SenderID:  senderStr,
 			BlockHash: []byte{1, 2, 3, 4},
@@ -259,9 +259,9 @@ func TestStateApi_checkPreCommit(t *testing.T) {
 
 	for i := 1; i < 6; i++ {
 		senderStr := "user"
-		senderStr += string(i)
+		senderStr += strconv.Itoa(i)
 		precommitMsgPool.Save(&pbft.PreCommitMsg{
-			MsgID:    "m" + string(i),
+			MsgID:    "m" + strconv.Itoa(i),
 			StateID:  pbft.StateID{"state"},
 			SenderID: senderStr,
 		})
@@ -298,9 +298,9 @@ func TestStateApi_updatePrevoteMsgPool(t *testing.T) {
 	msgNum := 2
 	for i := 0; i < msgNum; i++ {
 		msg := pbft.PrevoteMsg{
-			MsgID:     "m" + string(i),
+			MsgID:     "m" + strconv.Itoa(i),
 			StateID:   pbft.StateID{"sid"},
-			SenderID:  string(i),
+			SenderID:  strconv.Itoa(i),
 			BlockHash: []byte{'h', 'a', 's', 'h'},
 		}
 		stateApi.tempPrevoteMsgPool.Save(&msg)
@@ -314,6 +314,25 @@ func TestStateApi_updatePrevoteMsgPool(t *testing.T) {
 
 	// then
 	assert.Equal(t, 0, len(stateApi.tempPrevoteMsgPool.FindAll()))
+	assert.Equal(t, msgNum, len(loadedState.PrevoteMsgPool.FindAll()))
+
+	// given
+	for i := 0; i < 3; i++ {
+		msg := pbft.PrevoteMsg{
+			MsgID:     "msg" + strconv.Itoa(i),
+			StateID:   pbft.StateID{"sid2"},
+			SenderID:  "sender" + strconv.Itoa(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		stateApi.tempPrevoteMsgPool.Save(&msg)
+	}
+
+	// when
+	loadedState, _ = stateApi.stateRepository.Load()
+	loadedState = stateApi.updatePrevoteMsgPool(loadedState)
+
+	// then
+	assert.Equal(t, 3, len(stateApi.tempPrevoteMsgPool.FindAll()))
 	assert.Equal(t, msgNum, len(loadedState.PrevoteMsgPool.FindAll()))
 }
 
@@ -342,9 +361,9 @@ func TestStateApi_updatePreCommitMsgPool(t *testing.T) {
 	msgNum := 3
 	for i := 0; i < msgNum; i++ {
 		msg := pbft.PreCommitMsg{
-			MsgID:    "m" + string(i),
+			MsgID:    "m" + strconv.Itoa(i),
 			StateID:  pbft.StateID{"sid"},
-			SenderID: string(i),
+			SenderID: strconv.Itoa(i),
 		}
 		stateApi.tempPreCommitMsgPool.Save(&msg)
 	}
@@ -357,6 +376,24 @@ func TestStateApi_updatePreCommitMsgPool(t *testing.T) {
 
 	// then
 	assert.Equal(t, 0, len(stateApi.tempPreCommitMsgPool.FindAll()))
+	assert.Equal(t, msgNum, len(loadedState.PreCommitMsgPool.FindAll()))
+
+	// given
+	for i := 0; i < 3; i++ {
+		msg := pbft.PreCommitMsg{
+			MsgID:    "msg" + strconv.Itoa(i),
+			StateID:  pbft.StateID{"sid2"},
+			SenderID: "sender" + strconv.Itoa(i),
+		}
+		stateApi.tempPreCommitMsgPool.Save(&msg)
+	}
+
+	// when
+	loadedState, _ = stateApi.stateRepository.Load()
+	loadedState = stateApi.updatePreCommitMsgPool(loadedState)
+
+	// then
+	assert.Equal(t, 3, len(stateApi.tempPreCommitMsgPool.FindAll()))
 	assert.Equal(t, msgNum, len(loadedState.PreCommitMsgPool.FindAll()))
 }
 

--- a/consensus/pbft/state.go
+++ b/consensus/pbft/state.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/rs/xid"
 )
 
 type Stage string
@@ -94,6 +96,7 @@ func (pp ProposeMsg) ToByte() ([]byte, error) {
 }
 
 type PrevoteMsg struct {
+	MsgID     string
 	StateID   StateID
 	SenderID  string
 	BlockHash []byte
@@ -101,6 +104,7 @@ type PrevoteMsg struct {
 
 func NewPrevoteMsg(s *State, senderID string) *PrevoteMsg {
 	return &PrevoteMsg{
+		MsgID:     xid.New().String(),
 		StateID:   s.StateID,
 		SenderID:  senderID,
 		BlockHash: s.Block.Seal,
@@ -116,12 +120,14 @@ func (p PrevoteMsg) ToByte() ([]byte, error) {
 }
 
 type PreCommitMsg struct {
+	MsgID    string
 	StateID  StateID
 	SenderID string
 }
 
 func NewPreCommitMsg(s *State, senderID string) *PreCommitMsg {
 	return &PreCommitMsg{
+		MsgID:    xid.New().String(),
 		StateID:  s.StateID,
 		SenderID: senderID,
 	}

--- a/consensus/pbft/state_internal_test.go
+++ b/consensus/pbft/state_internal_test.go
@@ -1,10 +1,62 @@
 package pbft
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestPrevoteMsgPool_checkSenderExisting(t *testing.T) {
+	// given
+	msgPool := NewPrevoteMsgPool()
+
+	for i := 1; i < 4; i++ {
+		msgPool.Save(&PrevoteMsg{
+			MsgID:     "msg" + strconv.Itoa(i),
+			StateID:   StateID{"state1"},
+			SenderID:  "sender1",
+			BlockHash: []byte{1, 2, 3, 4},
+		})
+	}
+
+	// when : existing
+	result := msgPool.checkSenderExisting("sender1")
+
+	// then
+	assert.True(t, result)
+
+	// when : not existing
+	result = msgPool.checkSenderExisting("sender2")
+
+	// then
+	assert.False(t, result)
+}
+
+func TestPreCommitMsgPool_checkSenderExisting(t *testing.T) {
+	// given
+	msgPool := NewPreCommitMsgPool()
+
+	for i := 1; i < 4; i++ {
+		msgPool.Save(&PreCommitMsg{
+			MsgID:    "msg" + strconv.Itoa(i),
+			StateID:  StateID{"state1"},
+			SenderID: "sender1",
+		})
+	}
+
+	// when : existing
+	result := msgPool.checkSenderExisting("sender1")
+
+	// then
+	assert.True(t, result)
+
+	// when : not existing
+	result = msgPool.checkSenderExisting("sender2")
+
+	// then
+	assert.False(t, result)
+}
 
 // When Representative Number : 6, prevoteMsg Num : 4 -> then true
 func TestState_CheckPrevoteCondition_Satisfy(t *testing.T) {
@@ -13,9 +65,9 @@ func TestState_CheckPrevoteCondition_Satisfy(t *testing.T) {
 	satisfyPrevoteConditionState.PrevoteMsgPool = NewPrevoteMsgPool()
 	for i := 0; i < 4; i++ {
 		msg := PrevoteMsg{
-			MsgID:     "msg" + string(i),
+			MsgID:     "msg" + strconv.Itoa(i),
 			StateID:   StateID{"state1"},
-			SenderID:  "user" + string(i),
+			SenderID:  "user" + strconv.Itoa(i),
 			BlockHash: []byte{1, 2, 3, 4},
 		}
 		satisfyPrevoteConditionState.PrevoteMsgPool.Save(&msg)
@@ -30,9 +82,9 @@ func TestState_CheckPrevoteCondition_UnSatisfy(t *testing.T) {
 	unSatisfyPrevoteConditionState.PrevoteMsgPool = NewPrevoteMsgPool()
 	for i := 0; i < 2; i++ {
 		msg := PrevoteMsg{
-			MsgID:     "msg" + string(i),
+			MsgID:     "msg" + strconv.Itoa(i),
 			StateID:   StateID{"state1"},
-			SenderID:  "user" + string(i),
+			SenderID:  "user" + strconv.Itoa(i),
 			BlockHash: []byte{1, 2, 3, 4},
 		}
 		unSatisfyPrevoteConditionState.PrevoteMsgPool.Save(&msg)
@@ -49,9 +101,9 @@ func TestState_CheckPreCommitCondition_Satisfy(t *testing.T) {
 	satisfyPrecommitConditionState.PreCommitMsgPool = NewPreCommitMsgPool()
 	for i := 0; i < 4; i++ {
 		msg := PreCommitMsg{
-			MsgID:    "msg" + string(i),
+			MsgID:    "msg" + strconv.Itoa(i),
 			StateID:  StateID{"state1"},
-			SenderID: "user" + string(i),
+			SenderID: "user" + strconv.Itoa(i),
 		}
 		satisfyPrecommitConditionState.PreCommitMsgPool.Save(&msg)
 	}
@@ -65,9 +117,9 @@ func TestState_CheckPreCommitCondition_UnSatisfy(t *testing.T) {
 	unSatisfyPrecommitConditionState.PreCommitMsgPool = NewPreCommitMsgPool()
 	for i := 0; i < 2; i++ {
 		msg := PreCommitMsg{
-			MsgID:    "msg" + string(i),
+			MsgID:    "msg" + strconv.Itoa(i),
 			StateID:  StateID{"state1"},
-			SenderID: "user" + string(i),
+			SenderID: "user" + strconv.Itoa(i),
 		}
 		unSatisfyPrecommitConditionState.PreCommitMsgPool.Save(&msg)
 	}
@@ -80,7 +132,7 @@ func setUpState() State {
 	reps := make([]Representative, 0)
 	for i := 0; i < 6; i++ {
 		reps = append(reps, Representative{
-			ID: "user" + string(i),
+			ID: "user" + strconv.Itoa(i),
 		})
 	}
 

--- a/consensus/pbft/state_internal_test.go
+++ b/consensus/pbft/state_internal_test.go
@@ -10,14 +10,16 @@ import (
 func TestState_CheckPrevoteCondition_Satisfy(t *testing.T) {
 	// 6 rep
 	satisfyPrevoteConditionState := setUpState()
-	prevoteMsgs := make([]PrevoteMsg, 0)
+	satisfyPrevoteConditionState.PrevoteMsgPool = NewPrevoteMsgPool()
 	for i := 0; i < 4; i++ {
-		prevoteMsgs = append(prevoteMsgs, PrevoteMsg{
-			StateID:  StateID{"state1"},
-			SenderID: "user1",
-		})
+		msg := PrevoteMsg{
+			MsgID:     "msg" + string(i),
+			StateID:   StateID{"state1"},
+			SenderID:  "user" + string(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		satisfyPrevoteConditionState.PrevoteMsgPool.Save(&msg)
 	}
-	satisfyPrevoteConditionState.PrevoteMsgPool = PrevoteMsgPool{messages: prevoteMsgs}
 
 	assert.Equal(t, true, satisfyPrevoteConditionState.CheckPrevoteCondition())
 }
@@ -25,14 +27,17 @@ func TestState_CheckPrevoteCondition_Satisfy(t *testing.T) {
 // When Representative Number : 6, prevoteMsg Number : 2 -> then false
 func TestState_CheckPrevoteCondition_UnSatisfy(t *testing.T) {
 	unSatisfyPrevoteConditionState := setUpState()
-	prevoteMsgs := make([]PrevoteMsg, 0)
+	unSatisfyPrevoteConditionState.PrevoteMsgPool = NewPrevoteMsgPool()
 	for i := 0; i < 2; i++ {
-		prevoteMsgs = append(prevoteMsgs, PrevoteMsg{
-			StateID:  StateID{"state1"},
-			SenderID: "user1",
-		})
+		msg := PrevoteMsg{
+			MsgID:     "msg" + string(i),
+			StateID:   StateID{"state1"},
+			SenderID:  "user" + string(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		unSatisfyPrevoteConditionState.PrevoteMsgPool.Save(&msg)
+
 	}
-	unSatisfyPrevoteConditionState.PrevoteMsgPool = PrevoteMsgPool{messages: prevoteMsgs}
 
 	//then false
 	assert.Equal(t, false, unSatisfyPrevoteConditionState.CheckPrevoteCondition())
@@ -41,30 +46,31 @@ func TestState_CheckPrevoteCondition_UnSatisfy(t *testing.T) {
 // When Representative Number : 6, prevoteCommitMsg Number : 4 -> then true
 func TestState_CheckPreCommitCondition_Satisfy(t *testing.T) {
 	satisfyPrecommitConditionState := setUpState()
-	precommitMsgs := make([]PreCommitMsg, 0)
+	satisfyPrecommitConditionState.PreCommitMsgPool = NewPreCommitMsgPool()
 	for i := 0; i < 4; i++ {
-		precommitMsgs = append(precommitMsgs, PreCommitMsg{
+		msg := PreCommitMsg{
+			MsgID:    "msg" + string(i),
 			StateID:  StateID{"state1"},
-			SenderID: "user1",
-		})
+			SenderID: "user" + string(i),
+		}
+		satisfyPrecommitConditionState.PreCommitMsgPool.Save(&msg)
 	}
-	satisfyPrecommitConditionState.PreCommitMsgPool = PreCommitMsgPool{messages: precommitMsgs}
 
 	assert.Equal(t, true, satisfyPrecommitConditionState.CheckPreCommitCondition())
 }
 
 // When Representative Number : 6, prevoteCommitMsg Number : 2 -> then false
 func TestState_CheckPreCommitCondition_UnSatisfy(t *testing.T) {
-
 	unSatisfyPrecommitConditionState := setUpState()
-	precommitMsgs := make([]PreCommitMsg, 0)
+	unSatisfyPrecommitConditionState.PreCommitMsgPool = NewPreCommitMsgPool()
 	for i := 0; i < 2; i++ {
-		precommitMsgs = append(precommitMsgs, PreCommitMsg{
+		msg := PreCommitMsg{
+			MsgID:    "msg" + string(i),
 			StateID:  StateID{"state1"},
-			SenderID: "user1",
-		})
+			SenderID: "user" + string(i),
+		}
+		unSatisfyPrecommitConditionState.PreCommitMsgPool.Save(&msg)
 	}
-	unSatisfyPrecommitConditionState.PreCommitMsgPool = PreCommitMsgPool{messages: precommitMsgs}
 
 	assert.Equal(t, false, unSatisfyPrecommitConditionState.CheckPreCommitCondition())
 }
@@ -74,7 +80,7 @@ func setUpState() State {
 	reps := make([]Representative, 0)
 	for i := 0; i < 6; i++ {
 		reps = append(reps, Representative{
-			ID: "user",
+			ID: "user" + string(i),
 		})
 	}
 

--- a/consensus/pbft/state_test.go
+++ b/consensus/pbft/state_test.go
@@ -18,6 +18,7 @@ package pbft_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/it-chain/engine/consensus/pbft"
@@ -105,6 +106,91 @@ func TestPrevoteMsgPool_RemoveAllMsgs(t *testing.T) {
 	assert.Equal(t, 0, len(pPool.FindAll()))
 }
 
+func TestPrevoteMsgPool_Remove(t *testing.T) {
+	// given
+	pPool := pbft.NewPrevoteMsgPool()
+
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PrevoteMsg{
+			MsgID:     "m" + strconv.Itoa(i),
+			StateID:   pbft.StateID{"state1"},
+			SenderID:  "sender" + strconv.Itoa(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		pPool.Save(&pMsg)
+	}
+
+	assert.Equal(t, 3, len(pPool.FindAll()))
+
+	// when : success
+	pPool.Remove("m3")
+
+	// then
+	assert.Equal(t, 2, len(pPool.FindAll()))
+
+	// when : fail
+	pPool.Remove("m4")
+
+	// then
+	assert.Equal(t, 2, len(pPool.FindAll()))
+}
+
+func TestPrevoteMsgPool_FindAll(t *testing.T) {
+	// given
+	pPool := pbft.NewPrevoteMsgPool()
+
+	// when
+	numOfMsg := len(pPool.FindAll())
+
+	// then
+	assert.Equal(t, 0, numOfMsg)
+
+	// given
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PrevoteMsg{
+			MsgID:     "m" + strconv.Itoa(i),
+			StateID:   pbft.StateID{"state1"},
+			SenderID:  "sender" + strconv.Itoa(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		pPool.Save(&pMsg)
+	}
+
+	// when
+	result := pPool.FindAll()
+	numOfMsg = len(result)
+
+	// then
+	assert.Equal(t, 3, numOfMsg)
+}
+
+func TestPrevoteMsgPool_FindById(t *testing.T) {
+	// given
+	pPool := pbft.NewPrevoteMsgPool()
+
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PrevoteMsg{
+			MsgID:     "m" + strconv.Itoa(i),
+			StateID:   pbft.StateID{"state1"},
+			SenderID:  "sender" + strconv.Itoa(i),
+			BlockHash: []byte{1, 2, 3, 4},
+		}
+		pPool.Save(&pMsg)
+	}
+
+	// when : success
+	result := pPool.FindById("m1")
+
+	// then
+	assert.Equal(t, "m1", result.MsgID)
+
+	// when : fail
+	result = pPool.FindById("m4")
+
+	// then
+	assert.Equal(t, "", result.MsgID)
+}
+
 func TestPreCommitMsgPool_Save(t *testing.T) {
 	// given
 	cPool := pbft.NewPreCommitMsgPool()
@@ -166,6 +252,88 @@ func TestPreCommitMsgPool_RemoveAllMsgs(t *testing.T) {
 
 	// then
 	assert.Equal(t, 0, len(cPool.FindAll()))
+}
+
+func TestPreCommitMsgPool_Remove(t *testing.T) {
+	// given
+	pPool := pbft.NewPreCommitMsgPool()
+
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PreCommitMsg{
+			MsgID:    "m" + strconv.Itoa(i),
+			StateID:  pbft.StateID{"state1"},
+			SenderID: "sender" + strconv.Itoa(i),
+		}
+		pPool.Save(&pMsg)
+	}
+
+	assert.Equal(t, 3, len(pPool.FindAll()))
+
+	// when : success
+	pPool.Remove("m3")
+
+	// then
+	assert.Equal(t, 2, len(pPool.FindAll()))
+
+	// when : fail
+	pPool.Remove("m4")
+
+	// then
+	assert.Equal(t, 2, len(pPool.FindAll()))
+}
+
+func TestPreCommiteMsgPool_FindAll(t *testing.T) {
+	// given
+	pPool := pbft.NewPreCommitMsgPool()
+
+	// when
+	numOfMsg := len(pPool.FindAll())
+
+	// then
+	assert.Equal(t, 0, numOfMsg)
+
+	// given
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PreCommitMsg{
+			MsgID:    "m" + strconv.Itoa(i),
+			StateID:  pbft.StateID{"state1"},
+			SenderID: "sender" + strconv.Itoa(i),
+		}
+		pPool.Save(&pMsg)
+	}
+
+	// when
+	result := pPool.FindAll()
+	numOfMsg = len(result)
+
+	// then
+	assert.Equal(t, 3, numOfMsg)
+}
+
+func TestPreCommitMsgPool_FindById(t *testing.T) {
+	// given
+	pPool := pbft.NewPreCommitMsgPool()
+
+	for i := 1; i < 4; i++ {
+		pMsg := pbft.PreCommitMsg{
+			MsgID:    "m" + strconv.Itoa(i),
+			StateID:  pbft.StateID{"state1"},
+			SenderID: "sender" + strconv.Itoa(i),
+		}
+		pPool.Save(&pMsg)
+	}
+
+	// when : success
+	result := pPool.FindById("m1")
+
+	// then
+	assert.Equal(t, "m1", result.MsgID)
+
+	// when : fail
+	result = pPool.FindById("m4")
+
+	// then
+	assert.Equal(t, "", result.MsgID)
 }
 
 func TestState_GetReceipients(t *testing.T) {

--- a/consensus/pbft/state_test.go
+++ b/consensus/pbft/state_test.go
@@ -30,6 +30,7 @@ func TestPrevoteMsgPool_Save(t *testing.T) {
 
 	// case 1 : save
 	pMsg := pbft.PrevoteMsg{
+		MsgID:     "m1",
 		StateID:   pbft.StateID{"c1"},
 		SenderID:  "s1",
 		BlockHash: make([]byte, 0),
@@ -39,10 +40,11 @@ func TestPrevoteMsgPool_Save(t *testing.T) {
 	pPool.Save(&pMsg)
 
 	// then
-	assert.Equal(t, 1, len(pPool.Get()))
+	assert.Equal(t, 1, len(pPool.FindAll()))
 
 	// case 2 : save
 	pMsg = pbft.PrevoteMsg{
+		MsgID:     "m2",
 		StateID:   pbft.StateID{"c1"},
 		SenderID:  "s2",
 		BlockHash: make([]byte, 0),
@@ -52,10 +54,11 @@ func TestPrevoteMsgPool_Save(t *testing.T) {
 	pPool.Save(&pMsg)
 
 	// then
-	assert.Equal(t, 2, len(pPool.Get()))
+	assert.Equal(t, 2, len(pPool.FindAll()))
 
 	// case 3 : same sender
 	pMsg = pbft.PrevoteMsg{
+		MsgID:     "m3",
 		StateID:   pbft.StateID{"c1"},
 		SenderID:  "s2",
 		BlockHash: make([]byte, 0),
@@ -65,10 +68,11 @@ func TestPrevoteMsgPool_Save(t *testing.T) {
 	pPool.Save(&pMsg)
 
 	// then
-	assert.Equal(t, 2, len(pPool.Get()))
+	assert.Equal(t, 2, len(pPool.FindAll()))
 
 	// case 4 : block hash is is nil
 	pMsg = pbft.PrevoteMsg{
+		MsgID:     "m4",
 		StateID:   pbft.StateID{"c1"},
 		SenderID:  "s3",
 		BlockHash: nil,
@@ -78,7 +82,7 @@ func TestPrevoteMsgPool_Save(t *testing.T) {
 	pPool.Save(&pMsg)
 
 	// then
-	assert.Equal(t, 2, len(pPool.Get()))
+	assert.Equal(t, 2, len(pPool.FindAll()))
 }
 
 func TestPrevoteMsgPool_RemoveAllMsgs(t *testing.T) {
@@ -86,6 +90,7 @@ func TestPrevoteMsgPool_RemoveAllMsgs(t *testing.T) {
 	pPool := pbft.NewPrevoteMsgPool()
 
 	pMsg := pbft.PrevoteMsg{
+		MsgID:     "m1",
 		StateID:   pbft.StateID{"c1"},
 		SenderID:  "s1",
 		BlockHash: make([]byte, 0),
@@ -97,7 +102,7 @@ func TestPrevoteMsgPool_RemoveAllMsgs(t *testing.T) {
 	pPool.RemoveAllMsgs()
 
 	// then
-	assert.Equal(t, 0, len(pPool.Get()))
+	assert.Equal(t, 0, len(pPool.FindAll()))
 }
 
 func TestPreCommitMsgPool_Save(t *testing.T) {
@@ -106,6 +111,7 @@ func TestPreCommitMsgPool_Save(t *testing.T) {
 
 	// case 1 : save
 	cMsg := pbft.PreCommitMsg{
+		MsgID:    "m1",
 		StateID:  pbft.StateID{"c1"},
 		SenderID: "s1",
 	}
@@ -114,10 +120,11 @@ func TestPreCommitMsgPool_Save(t *testing.T) {
 	cPool.Save(&cMsg)
 
 	// then
-	assert.Equal(t, 1, len(cPool.Get()))
+	assert.Equal(t, 1, len(cPool.FindAll()))
 
 	// case 2 : save
 	cMsg = pbft.PreCommitMsg{
+		MsgID:    "m2",
 		StateID:  pbft.StateID{"c1"},
 		SenderID: "s2",
 	}
@@ -126,10 +133,11 @@ func TestPreCommitMsgPool_Save(t *testing.T) {
 	cPool.Save(&cMsg)
 
 	// then
-	assert.Equal(t, 2, len(cPool.Get()))
+	assert.Equal(t, 2, len(cPool.FindAll()))
 
 	// case 3 : same sender
 	cMsg = pbft.PreCommitMsg{
+		MsgID:    "m3",
 		StateID:  pbft.StateID{"c1"},
 		SenderID: "s2",
 	}
@@ -138,7 +146,7 @@ func TestPreCommitMsgPool_Save(t *testing.T) {
 	cPool.Save(&cMsg)
 
 	// then
-	assert.Equal(t, 2, len(cPool.Get()))
+	assert.Equal(t, 2, len(cPool.FindAll()))
 }
 
 func TestPreCommitMsgPool_RemoveAllMsgs(t *testing.T) {
@@ -146,6 +154,7 @@ func TestPreCommitMsgPool_RemoveAllMsgs(t *testing.T) {
 	cPool := pbft.NewPreCommitMsgPool()
 
 	cMsg := pbft.PreCommitMsg{
+		MsgID:    "m1",
 		StateID:  pbft.StateID{"c1"},
 		SenderID: "s1",
 	}
@@ -156,7 +165,7 @@ func TestPreCommitMsgPool_RemoveAllMsgs(t *testing.T) {
 	cPool.RemoveAllMsgs()
 
 	// then
-	assert.Equal(t, 0, len(cPool.Get()))
+	assert.Equal(t, 0, len(cPool.FindAll()))
 }
 
 func TestState_GetReceipients(t *testing.T) {
@@ -211,6 +220,7 @@ func TestState_SavePrevoteMsg(t *testing.T) {
 
 	// case 1 : save
 	pMsg := &pbft.PrevoteMsg{
+		MsgID:     "m1",
 		StateID:   pbft.NewStateID("c1"),
 		SenderID:  "s1",
 		BlockHash: make([]byte, 0),
@@ -221,11 +231,12 @@ func TestState_SavePrevoteMsg(t *testing.T) {
 
 	// then
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(c.PrevoteMsgPool.Get()))
-	assert.Equal(t, *pMsg, c.PrevoteMsgPool.Get()[0])
+	assert.Equal(t, 1, len(c.PrevoteMsgPool.FindAll()))
+	assert.Equal(t, *pMsg, c.PrevoteMsgPool.FindAll()[0])
 
 	// case 2 : incorrect consensus ID
 	pMsg = &pbft.PrevoteMsg{
+		MsgID:     "m2",
 		StateID:   pbft.NewStateID("c2"),
 		SenderID:  "s1",
 		BlockHash: make([]byte, 0),
@@ -236,7 +247,7 @@ func TestState_SavePrevoteMsg(t *testing.T) {
 
 	//then
 	assert.Error(t, err)
-	assert.Equal(t, 1, len(c.PrevoteMsgPool.Get()))
+	assert.Equal(t, 1, len(c.PrevoteMsgPool.FindAll()))
 }
 
 func TestState_SavePreCommitMsg(t *testing.T) {
@@ -254,6 +265,7 @@ func TestState_SavePreCommitMsg(t *testing.T) {
 
 	// case 1 : save
 	cMsg := &pbft.PreCommitMsg{
+		MsgID:    "m1",
 		StateID:  pbft.NewStateID("c1"),
 		SenderID: "s1",
 	}
@@ -263,11 +275,12 @@ func TestState_SavePreCommitMsg(t *testing.T) {
 
 	// then
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(c.PreCommitMsgPool.Get()))
-	assert.Equal(t, *cMsg, c.PreCommitMsgPool.Get()[0])
+	assert.Equal(t, 1, len(c.PreCommitMsgPool.FindAll()))
+	assert.Equal(t, *cMsg, c.PreCommitMsgPool.FindAll()[0])
 
 	// case 2 : incorrect consensus ID
 	cMsg = &pbft.PreCommitMsg{
+		MsgID:    "m2",
 		StateID:  pbft.NewStateID("c2"),
 		SenderID: "s1",
 	}
@@ -277,5 +290,5 @@ func TestState_SavePreCommitMsg(t *testing.T) {
 
 	//then
 	assert.Error(t, err)
-	assert.Equal(t, 1, len(c.PreCommitMsgPool.Get()))
+	assert.Equal(t, 1, len(c.PreCommitMsgPool.FindAll()))
 }


### PR DESCRIPTION
resolved: #1033 

details:

1. Add a msg id to prevote/precommit msg.
2. From array to map.
3. Add "RemoveByMsgId" to msg pool.
4. In func UpdateMsgPool of state api, save messages which have same state id and not duplicated sender id from temp msg pool to msg pool.
5. Modify test cases.

 - [x] Test case
